### PR TITLE
Fixed Log file to give correct filenames

### DIFF
--- a/cluster-director-slurm/pkg/tools/cluster/clusterCore.go
+++ b/cluster-director-slurm/pkg/tools/cluster/clusterCore.go
@@ -201,7 +201,6 @@ func getAllZonesInRegion(region string, projectID string, ctx context.Context, c
 	// The 'Do' method handles pagination for you. We process each page of results.
 	if err := req1.Pages(ctx, func(page *compute.ZoneList) error {
 		for _, zone := range page.Items {
-			genericCore.WriteToLog(zone.Name)
 			zonesList = append(zonesList, zone.Name)
 		}
 		return nil
@@ -256,7 +255,6 @@ func getAllRegionsAndZonesSupportedByHCS(projectID string) bool {
 	}
 	// Now you can access the data through the struct
 	for _, loc := range locationData.Locations {
-		genericCore.WriteToLog("Region: " + loc.LocationID)
 		regions2Zones[loc.LocationID] = getAllZonesInRegion(loc.LocationID, projectID, ctx, computeService)
 	}
 
@@ -317,7 +315,7 @@ func getClustersInRegionIfExists(region string, projectID string) {
 	region2ClusterNames[region] = []string{}
 
 	bodyString, success := genericCore.QueryURLAndGetResult(authToken, url)
-	genericCore.WriteToLog(fmt.Sprintf("Response from Cluster Director API on the clusters in region %s : %s ", region, string(bodyString)))
+	genericCore.WriteToLog(fmt.Sprintf("Response received from Cluster Director API for region %s (Payload Size: %d bytes)", region, len(bodyString)))
 	// If the body has "storages" than that means it is a cluster
 	if success && strings.Contains(bodyString, "storages") {
 		genericCore.WriteToLog("Trying to parse JSON...")

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -16,12 +16,14 @@ package genericCore
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -34,28 +36,77 @@ func WriteToLog(message string) {
 
 	if logger == nil {
 		f := CreateUniqueFilePath("logs/log.cluster-director-mcp")
-
-		// Configure handler options
-		opts := &slog.HandlerOptions{
-			AddSource: true,           // Include file and line number
-			Level:     slog.LevelInfo, // Default level
-		}
-
-		// If file creation succeeded, write to file. Otherwise, write to stdout.
+		var writer io.Writer
 		if f != nil {
-			logger = slog.New(slog.NewTextHandler(f, opts))
+			writer = f
 		} else {
-			logger = slog.New(slog.NewTextHandler(os.Stdout, opts))
+			writer = os.Stdout
 		}
 
-		// Set this as the default logger for the application
+		opts := &slog.HandlerOptions{
+			AddSource: true,
+			Level:     slog.LevelInfo,
+		}
+
+		// Initialize the custom handler
+		handler := &PlainHandler{
+			w:    writer,
+			opts: *opts,
+		}
+
+		logger = slog.New(handler)
 		slog.SetDefault(logger)
 	}
 
-	// Log the message.
-	// slog automatically adds "time", "level", and "source" attributes.
-	logger.Info(message)
+	// 1. Capture the Program Counter (PC) of the caller
+	// We skip 2 frames:
+	// 0 = runtime.Callers
+	// 1 = WriteToLog
+	// 2 = The function calling WriteToLog (e.g., clusterCore.go)
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:])
+
+	// 2. Create the record with the specific PC
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, message, pcs[0])
+
+	// 3. Handle the record
+	_ = logger.Handler().Handle(context.Background(), r)
 }
+
+type PlainHandler struct {
+	w    io.Writer
+	opts slog.HandlerOptions
+}
+
+// Enabled reports whether the handler handles records at the given level.
+func (h *PlainHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= h.opts.Level.Level()
+}
+
+// Handle formats the record as a plain string without keys
+func (h *PlainHandler) Handle(ctx context.Context, r slog.Record) error {
+	// 1. Format Time
+	timeStr := r.Time.Format(time.RFC3339)
+
+	// 2. Format Source (File:Line)
+	sourceStr := ""
+	if h.opts.AddSource && r.PC != 0 {
+		fs := runtime.CallersFrames([]uintptr{r.PC})
+		f, _ := fs.Next()
+		sourceStr = fmt.Sprintf("%s:%d", f.File, f.Line)
+	}
+
+	// 3. Format Level
+	levelStr := r.Level.String()
+
+	// 4. Construct the final string: "TIME LEVEL SOURCE MESSAGE"
+	_, err := fmt.Fprintf(h.w, "%s %s %s %s\n", timeStr, levelStr, sourceStr, r.Message)
+	return err
+}
+
+func (h *PlainHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+
+func (h *PlainHandler) WithGroup(name string) slog.Handler { return h }
 
 // SearchByColumn1 searches for a target string in the second column (index 1).
 // It returns the found row and true, or nil and false if not found.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/logging v1.13.0
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/net v0.42.0
 	google.golang.org/api v0.244.0
 	google.golang.org/protobuf v1.36.6
 )
@@ -37,7 +38,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
-	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect


### PR DESCRIPTION
This PR resolves the issue where the logging wrapper (genericCore.go) was incorrectly reported as the source for all log entries; the logger now correctly skips stack frames to identify the actual file and line number of the caller. Additionally, it implements a custom handler to remove standard key-value prefixes (e.g., msg=, source=, level=), resulting in a cleaner, plain-text log format, and removes the verbose debug logging of individual zone names.