### PR TITLE
Shows consumption type of GCE instance

### DIFF
--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -50,6 +50,13 @@ When a user asks for specific "details", "machines", "GPUs", or "specs" for a na
    - **Sharing:** `shareSettings` and `reservationSharingPolicy`
    - **Resource State:** Full details from `resourceStatus`.
 
+### 3. Instance Consumption (Strict Partitioning Protocol)
+When checking a list of instances for consumption/spot status:
+- **Partitioning Rule:** You MUST split the input list into separate API calls based on the instance name:
+  1. **GKE Nodes:** Send names containing "gke" ONLY to `cluster-director-gke-ai__check_instance_consumption`.
+  2. **Slurm Nodes:** Send all other names to `cluster-director-slurm__check_instance_consumption`.
+- **Constraint:** Do NOT mix these lists. The GKE tool provides unreliable data for non-GKE nodes.
+
 ## Protocol & Guardrails
 - **Zero Truncation Rule:** If a reservation contains multiple GPUs or SSDs, you are strictly forbidden from summarizing them (e.g., "16 SSDs"). You must list each entry to ensure hardware interface visibility.
 - **Schema Fidelity:** Ensure your response labels match the API schema logic. If a field is missing in the JSON, report it as "Not Defined."

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -80,6 +80,7 @@ type SearchLogsResponse struct {
 	Status string `json:"status"`
 }
 
+// CheckConsumptionRequest defines the structure for the tool input
 type CheckConsumptionRequest struct {
 	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
 	Zone          string   `json:"Zone" jsonschema:"description=GCP Zone (e.g., us-central1-a). Optional: If omitted, the tool will search for the instances."`
@@ -878,36 +879,11 @@ func getVersionCheckStatus(projectID string, jobObj *persistence.LongRunningJob)
 
 // Implementation
 func (h *handlers) checkConsumptionMCP(ctx context.Context, req CheckConsumptionRequest) (string, error) {
-
-	var results []genericCore.InstanceConsumptionStatus
-
-	for _, name := range req.InstanceNames {
-		sharedReq := genericCore.CheckConsumptionRequestShared{
-			InstanceName: name,
-			Zone:         req.Zone,
-			ProjectID:    req.ProjectID,
-		}
-
-		info, err := genericCore.CheckInstanceConsumptionCore(ctx, sharedReq, h.c.GetDefaultProjectID())
-
-		if err != nil {
-			results = append(results, genericCore.InstanceConsumptionStatus{
-				InstanceName:      name,
-				ConsumptionStatus: fmt.Sprintf("Error: %v", err),
-			})
-		} else {
-			results = append(results, info)
-		}
-	}
-
-	if len(results) == 0 {
-		return "[]", nil
-	}
-
-	jsonBytes, err := json.MarshalIndent(results, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("failed to generate JSON output: %v", err)
-	}
-
-	return string(jsonBytes), nil
+	return genericCore.ProcessConsumptionRequest(
+		ctx,
+		req.InstanceNames,
+		req.Zone,
+		req.ProjectID,
+		h.c.GetDefaultProjectID(),
+	)
 }

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -80,6 +80,12 @@ type SearchLogsResponse struct {
 	Status string `json:"status"`
 }
 
+type CheckConsumptionRequest struct {
+	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
+	Zone          string   `json:"Zone" jsonschema:"description=GCP Zone (e.g., us-central1-a). Optional: If omitted, the tool will search for the instances."`
+	ProjectID     string   `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+}
+
 type handlers struct {
 	c *config.Config
 }
@@ -245,6 +251,48 @@ func Install(s *mcp.Server, c *config.Config) {
 				result += ". Your job is possibly slow because we found Xid errors on the nodes running it"
 			}
 			return nil, SearchLogsResponse{Status: result}, err
+		},
+	)
+
+	// Check Instance Consumption Type
+	checkConsumptionTool := mcp.Tool{
+		Name:        "check_instance_consumption",
+		Description: "Check if GKE (Kubernetes) cluster nodes are Spot, On-Demand, or consuming a Reservation. Use this for GKE clusters or GKE node pools.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"InstanceNames": map[string]interface{}{
+					"type": "array",
+					"items": map[string]interface{}{
+						"type": "string",
+					},
+					"description": "List of GCE instance names",
+				},
+				"Zone": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Zone. Optional: If omitted, the tool will search for the instances.",
+				},
+				"ProjectID": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Project ID. Optional.",
+				},
+			},
+			"required": []string{"InstanceNames"},
+		},
+	}
+	mcp.AddTool(
+		s,
+		&checkConsumptionTool,
+		func(ctx context.Context, _ *mcp.CallToolRequest, req CheckConsumptionRequest) (*mcp.CallToolResult, any, error) {
+			result, err := h.checkConsumptionMCP(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 		},
 	)
 
@@ -826,4 +874,40 @@ func getVersionCheckStatus(projectID string, jobObj *persistence.LongRunningJob)
 	}
 
 	return "Job is running...", true
+}
+
+// Implementation
+func (h *handlers) checkConsumptionMCP(ctx context.Context, req CheckConsumptionRequest) (string, error) {
+
+	var results []genericCore.InstanceConsumptionStatus
+
+	for _, name := range req.InstanceNames {
+		sharedReq := genericCore.CheckConsumptionRequestShared{
+			InstanceName: name,
+			Zone:         req.Zone,
+			ProjectID:    req.ProjectID,
+		}
+
+		info, err := genericCore.CheckInstanceConsumptionCore(ctx, sharedReq, h.c.GetDefaultProjectID())
+
+		if err != nil {
+			results = append(results, genericCore.InstanceConsumptionStatus{
+				InstanceName:      name,
+				ConsumptionStatus: fmt.Sprintf("Error: %v", err),
+			})
+		} else {
+			results = append(results, info)
+		}
+	}
+
+	if len(results) == 0 {
+		return "[]", nil
+	}
+
+	jsonBytes, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JSON output: %v", err)
+	}
+
+	return string(jsonBytes), nil
 }

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -131,6 +131,7 @@ type handlers struct {
 	c *config.Config
 }
 
+// CheckConsumptionRequest defines the structure for the tool input
 type CheckConsumptionRequest struct {
 	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
 	Zone          string   `json:"Zone" jsonschema:"description=GCP Zone (e.g., us-central1-a). Optional: If omitted, the tool will search for the instances."`
@@ -1646,35 +1647,11 @@ func getVersionCheckStatus(projectID string, jobObj *persistence.LongRunningJob)
 
 // Implementation
 func (h *handlers) checkConsumptionMCP(ctx context.Context, req CheckConsumptionRequest) (string, error) {
-	var results []genericCore.InstanceConsumptionStatus
-
-	for _, name := range req.InstanceNames {
-		sharedReq := genericCore.CheckConsumptionRequestShared{
-			InstanceName: name,
-			Zone:         req.Zone,
-			ProjectID:    req.ProjectID,
-		}
-
-		info, err := genericCore.CheckInstanceConsumptionCore(ctx, sharedReq, h.c.GetDefaultProjectID())
-
-		if err != nil {
-			results = append(results, genericCore.InstanceConsumptionStatus{
-				InstanceName:      name,
-				ConsumptionStatus: fmt.Sprintf("Error: %v", err),
-			})
-		} else {
-			results = append(results, info)
-		}
-	}
-
-	if len(results) == 0 {
-		return "[]", nil
-	}
-
-	jsonBytes, err := json.MarshalIndent(results, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("failed to generate JSON output: %v", err)
-	}
-
-	return string(jsonBytes), nil
+	return genericCore.ProcessConsumptionRequest(
+		ctx,
+		req.InstanceNames,
+		req.Zone,
+		req.ProjectID,
+		h.c.GetDefaultProjectID(),
+	)
 }

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -131,6 +131,12 @@ type handlers struct {
 	c *config.Config
 }
 
+type CheckConsumptionRequest struct {
+	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
+	Zone          string   `json:"Zone" jsonschema:"description=GCP Zone (e.g., us-central1-a). Optional: If omitted, the tool will search for the instances."`
+	ProjectID     string   `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+}
+
 func Install(s *mcp.Server, c *config.Config) {
 	h := &handlers{
 		c: c,
@@ -513,6 +519,48 @@ func Install(s *mcp.Server, c *config.Config) {
 			result, err := h.showClusterSoftwareVersionInfoMCP(ctx, &req)
 			return nil, SoftwareVersionInfoResponse{VersionInfo: result}, err
 		})
+
+	// Check Instance Consumption Type
+	checkConsumptionTool := mcp.Tool{
+		Name:        "check_instance_consumption",
+		Description: "Check if Slurm HPC cluster nodes (login or compute) are Spot, On-Demand, or consuming a Reservation. Use this for Slurm clusters.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"InstanceNames": map[string]interface{}{
+					"type": "array",
+					"items": map[string]interface{}{
+						"type": "string",
+					},
+					"description": "List of GCE instance names",
+				},
+				"Zone": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Zone. Optional: If omitted, the tool will search for the instances.",
+				},
+				"ProjectID": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Project ID. Optional.",
+				},
+			},
+			"required": []string{"InstanceNames"},
+		},
+	}
+	mcp.AddTool(
+		s,
+		&checkConsumptionTool,
+		func(ctx context.Context, _ *mcp.CallToolRequest, req CheckConsumptionRequest) (*mcp.CallToolResult, any, error) {
+			result, err := h.checkConsumptionMCP(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
+		},
+	)
 
 }
 
@@ -1594,4 +1642,39 @@ func getVersionCheckStatus(projectID string, jobObj *persistence.LongRunningJob)
 		return "Version Check Completed Successfully!", true
 	}
 	return "Job is running...", true
+}
+
+// Implementation
+func (h *handlers) checkConsumptionMCP(ctx context.Context, req CheckConsumptionRequest) (string, error) {
+	var results []genericCore.InstanceConsumptionStatus
+
+	for _, name := range req.InstanceNames {
+		sharedReq := genericCore.CheckConsumptionRequestShared{
+			InstanceName: name,
+			Zone:         req.Zone,
+			ProjectID:    req.ProjectID,
+		}
+
+		info, err := genericCore.CheckInstanceConsumptionCore(ctx, sharedReq, h.c.GetDefaultProjectID())
+
+		if err != nil {
+			results = append(results, genericCore.InstanceConsumptionStatus{
+				InstanceName:      name,
+				ConsumptionStatus: fmt.Sprintf("Error: %v", err),
+			})
+		} else {
+			results = append(results, info)
+		}
+	}
+
+	if len(results) == 0 {
+		return "[]", nil
+	}
+
+	jsonBytes, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JSON output: %v", err)
+	}
+
+	return string(jsonBytes), nil
 }

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -29,6 +29,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 )
 
 const maxLogFiles = 100
@@ -40,7 +43,23 @@ type GcloudListItem struct {
 	Name string `json:"name"`
 }
 
+type CheckConsumptionRequestShared struct {
+	InstanceName string
+	Zone         string
+	ProjectID    string
+}
+
+type InstanceConsumptionStatus struct {
+	InstanceName        string `json:"instance_name"`
+	Zone                string `json:"zone"`
+	ProvisioningModel   string `json:"provisioning_model"`
+	ReservationAffinity string `json:"reservation_affinity"`
+	ConsumptionStatus   string `json:"consumption_status"`
+}
+
 func WriteToLog(message string) {
+
+	message = strings.ReplaceAll(message, "\n", " | ")
 
 	if logger == nil {
 		f := CreateUniqueFilePath("logs/log.cluster-director-mcp")
@@ -366,4 +385,139 @@ func GetGCloudRegionsAndZones() ([]string, []string, error) {
 	}
 
 	return regions, zones, nil
+}
+
+func GetResourceNameFromURL(url string) string {
+	parts := strings.Split(url, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return url
+}
+
+func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionRequestShared, defaultProjectID string) (InstanceConsumptionStatus, error) {
+	WriteToLog("CheckInstanceConsumptionCore.0000")
+
+	var status InstanceConsumptionStatus
+	status.InstanceName = req.InstanceName
+	status.Zone = req.Zone
+
+	projectID := req.ProjectID
+	if projectID == "" {
+		projectID = defaultProjectID
+	}
+
+	service, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
+	if err != nil {
+		status.ConsumptionStatus = fmt.Sprintf("Failed to create compute service: %v", err)
+		return status, nil
+	}
+
+	// 1. Get Instance
+	var instance *compute.Instance
+	if req.Zone == "" {
+		// Search all zones if zone is missing
+		filter := fmt.Sprintf("name = \"%s\"", req.InstanceName)
+		found := false
+		err := service.Instances.AggregatedList(projectID).Filter(filter).Pages(ctx, func(page *compute.InstanceAggregatedList) error {
+			for _, list := range page.Items {
+				for _, inst := range list.Instances {
+					if inst.Name == req.InstanceName {
+						instance = inst
+						status.Zone = GetResourceNameFromURL(inst.Zone)
+						found = true
+						return nil
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil || !found {
+			status.ConsumptionStatus = fmt.Sprintf("Instance not found: %s", req.InstanceName)
+			return status, nil
+		}
+	} else {
+		// Direct fetch
+		instance, err = service.Instances.Get(projectID, req.Zone, req.InstanceName).Context(ctx).Do()
+		if err != nil {
+			status.ConsumptionStatus = fmt.Sprintf("Could not get instance: %v", err)
+			return status, nil
+		}
+	}
+
+	// 2. Check Spot Status
+	isSpot := false
+	status.ProvisioningModel = "STANDARD VM"
+	if instance.Scheduling != nil {
+		if instance.Scheduling.ProvisioningModel == "SPOT" {
+			status.ProvisioningModel = "SPOT VM (No max duration)"
+			isSpot = true
+		} else if instance.Scheduling.Preemptible {
+			status.ProvisioningModel = "LEGACY PREEMPTIBLE VM (24h max duration)"
+			isSpot = true
+		}
+	}
+
+	// 3. Check Reservation Status
+	if isSpot {
+		status.ReservationAffinity = "None (Spot VM)"
+		status.ConsumptionStatus = "Not consuming (Spot VMs cannot use reservations)"
+	} else {
+		consumeType := "ANY_RESERVATION"
+		if instance.ReservationAffinity != nil {
+			consumeType = instance.ReservationAffinity.ConsumeReservationType
+		}
+
+		switch consumeType {
+		case "NO_RESERVATION":
+			status.ReservationAffinity = "None (Explicitly disabled)"
+			status.ConsumptionStatus = "Not consuming (On-Demand)"
+
+		case "SPECIFIC_RESERVATION":
+			key := ""
+			val := ""
+			if instance.ReservationAffinity != nil {
+				key = instance.ReservationAffinity.Key
+				if len(instance.ReservationAffinity.Values) > 0 {
+					val = instance.ReservationAffinity.Values[0]
+				}
+			}
+			status.ReservationAffinity = fmt.Sprintf("Specific (Target: %s=%s)", key, val)
+			status.ConsumptionStatus = "Consuming (Specific Reservation)"
+
+		case "ANY_RESERVATION":
+			status.ReservationAffinity = "Automatic (Any matching reservation)"
+			foundMatchName := ""
+			req := service.Reservations.List(projectID, status.Zone)
+			_ = req.Pages(ctx, func(page *compute.ReservationList) error {
+				for _, res := range page.Items {
+					if res.SpecificReservationRequired || res.Status != "READY" {
+						continue
+					}
+					if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
+						resMachineType := GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
+						instMachineType := GetResourceNameFromURL(instance.MachineType)
+
+						if resMachineType == instMachineType {
+							foundMatchName = res.Name
+							return nil 
+						}
+					}
+				}
+				return nil
+			})
+
+			if foundMatchName != "" {
+				status.ConsumptionStatus = fmt.Sprintf("Consuming (%s)", foundMatchName)
+			} else {
+				status.ConsumptionStatus = "Not consuming (No matching reservation found)"
+			}
+
+		default:
+			status.ReservationAffinity = "Unknown"
+			status.ConsumptionStatus = "Not consuming (On-Demand)"
+		}
+	}
+
+	return status, nil
 }

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -43,12 +43,14 @@ type GcloudListItem struct {
 	Name string `json:"name"`
 }
 
+// CheckConsumptionRequestShared defines the input from the tool
 type CheckConsumptionRequestShared struct {
 	InstanceName string
 	Zone         string
 	ProjectID    string
 }
 
+// InstanceConsumptionStatus defines the JSON output structure
 type InstanceConsumptionStatus struct {
 	InstanceName        string `json:"instance_name"`
 	Zone                string `json:"zone"`
@@ -387,6 +389,7 @@ func GetGCloudRegionsAndZones() ([]string, []string, error) {
 	return regions, zones, nil
 }
 
+// GetResourceNameFromURL extracts the last part of a GCP URL (e.g., "us-central1-a" from ".../zones/us-central1-a")
 func GetResourceNameFromURL(url string) string {
 	parts := strings.Split(url, "/")
 	if len(parts) > 0 {
@@ -395,8 +398,47 @@ func GetResourceNameFromURL(url string) string {
 	return url
 }
 
+// This mimics the "list_clusters" behavior: if we don't know where it is, we search everywhere.
+func FindInstanceInProject(ctx context.Context, service *compute.Service, projectID, instanceName string) (*compute.Instance, string, error) {
+	filter := fmt.Sprintf("name = \"%s\"", instanceName)
+
+	var foundInstance *compute.Instance
+	var foundZone string
+
+	err := service.Instances.AggregatedList(projectID).Filter(filter).Pages(ctx, func(page *compute.InstanceAggregatedList) error {
+		for _, scopedList := range page.Items {
+			if len(scopedList.Instances) > 0 {
+				for _, inst := range scopedList.Instances {
+					if inst.Name == instanceName {
+						foundInstance = inst
+						foundZone = GetResourceNameFromURL(inst.Zone)
+						return nil 
+					}
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to search project %s: %v", projectID, err)
+	}
+
+	if foundInstance == nil {
+		return nil, "", fmt.Errorf("instance '%s' not found in any zone of project '%s'", instanceName, projectID)
+	}
+
+	return foundInstance, foundZone, nil
+}
+
+// CheckInstanceConsumptionCore is the main logic function.
+// It handles Auto-Discovery, Spot Checks, and Reservation Checks.
 func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionRequestShared, defaultProjectID string) (InstanceConsumptionStatus, error) {
 	WriteToLog("CheckInstanceConsumptionCore.0000")
+
+	req.InstanceName = strings.TrimSpace(req.InstanceName)
+	req.Zone = strings.TrimSpace(req.Zone)
+	req.ProjectID = strings.TrimSpace(req.ProjectID)
 
 	var status InstanceConsumptionStatus
 	status.InstanceName = req.InstanceName
@@ -420,39 +462,22 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 		if err == nil {
 			instance = inst
 			status.Zone = req.Zone
+		} else {
+			WriteToLog(fmt.Sprintf("Direct fetch failed for %s in %s: %v. Falling back to global search.", req.InstanceName, req.Zone, err))
 		}
 	}
 
 	if instance == nil {
-		filter := fmt.Sprintf("name = \"%s\"", req.InstanceName)
-		found := false
-
-		err := service.Instances.AggregatedList(projectID).Filter(filter).Pages(ctx, func(page *compute.InstanceAggregatedList) error {
-			for _, list := range page.Items {
-				for _, inst := range list.Instances {
-					if inst.Name == req.InstanceName {
-						instance = inst
-						status.Zone = GetResourceNameFromURL(inst.Zone)
-						found = true
-						return nil
-					}
-				}
-			}
-			return nil
-		})
-
-		if err != nil || !found {
-			errorMsg := fmt.Sprintf("Instance not found: %s", req.InstanceName)
-			if req.Zone != "" {
-				errorMsg += fmt.Sprintf(" (Checked %s and searched all zones)", req.Zone)
-			}
-			status.ConsumptionStatus = errorMsg
+		foundInst, foundZone, err := FindInstanceInProject(ctx, service, projectID, req.InstanceName)
+		if err != nil {
+			status.ConsumptionStatus = fmt.Sprintf("Error: %v. Check your PROJECT_ID configuration.", err)
 			return status, nil
 		}
+		instance = foundInst
+		status.Zone = foundZone
 	}
 
-	// Check Spot Status
-
+	//  Check Spot / Preemptible Status
 	isSpot := false
 	status.ProvisioningModel = "STANDARD VM"
 	if instance.Scheduling != nil {
@@ -465,7 +490,7 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 		}
 	}
 
-	// Check Reservation Status
+	//  Check Reservation Status
 	if isSpot {
 		status.ReservationAffinity = "None (Spot VM)"
 		status.ConsumptionStatus = "Not consuming (Spot VMs cannot use reservations)"
@@ -495,7 +520,6 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 		case "ANY_RESERVATION":
 			status.ReservationAffinity = "Automatic (Any matching reservation)"
 			foundMatchName := ""
-
 			reqRes := service.Reservations.List(projectID, status.Zone)
 
 			_ = reqRes.Pages(ctx, func(page *compute.ReservationList) error {
@@ -503,14 +527,13 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 					if res.SpecificReservationRequired || res.Status != "READY" {
 						continue
 					}
-
 					if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
 						resMachineType := GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
 						instMachineType := GetResourceNameFromURL(instance.MachineType)
 
 						if resMachineType == instMachineType {
 							foundMatchName = res.Name
-							return nil
+							return nil 
 						}
 					}
 				}
@@ -530,4 +553,39 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 	}
 
 	return status, nil
+}
+
+// ProcessConsumptionRequest handles the loop, error catching, and JSON formatting.
+func ProcessConsumptionRequest(ctx context.Context, instanceNames []string, zone, reqProjectID, defaultProjectID string) (string, error) {
+	var results []InstanceConsumptionStatus
+
+	for _, name := range instanceNames {
+		sharedReq := CheckConsumptionRequestShared{
+			InstanceName: name,
+			Zone:         zone,
+			ProjectID:    reqProjectID,
+		}
+
+		info, err := CheckInstanceConsumptionCore(ctx, sharedReq, defaultProjectID)
+
+		if err != nil {
+			results = append(results, InstanceConsumptionStatus{
+				InstanceName:      name,
+				ConsumptionStatus: fmt.Sprintf("Error: %v", err),
+			})
+		} else {
+			results = append(results, info)
+		}
+	}
+
+	if len(results) == 0 {
+		return "[]", nil
+	}
+
+	jsonBytes, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JSON output: %v", err)
+	}
+
+	return string(jsonBytes), nil
 }

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -413,12 +413,20 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 		return status, nil
 	}
 
-	// 1. Get Instance
 	var instance *compute.Instance
-	if req.Zone == "" {
-		// Search all zones if zone is missing
+
+	if req.Zone != "" {
+		inst, err := service.Instances.Get(projectID, req.Zone, req.InstanceName).Context(ctx).Do()
+		if err == nil {
+			instance = inst
+			status.Zone = req.Zone
+		}
+	}
+
+	if instance == nil {
 		filter := fmt.Sprintf("name = \"%s\"", req.InstanceName)
 		found := false
+
 		err := service.Instances.AggregatedList(projectID).Filter(filter).Pages(ctx, func(page *compute.InstanceAggregatedList) error {
 			for _, list := range page.Items {
 				for _, inst := range list.Instances {
@@ -432,20 +440,19 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 			}
 			return nil
 		})
+
 		if err != nil || !found {
-			status.ConsumptionStatus = fmt.Sprintf("Instance not found: %s", req.InstanceName)
-			return status, nil
-		}
-	} else {
-		// Direct fetch
-		instance, err = service.Instances.Get(projectID, req.Zone, req.InstanceName).Context(ctx).Do()
-		if err != nil {
-			status.ConsumptionStatus = fmt.Sprintf("Could not get instance: %v", err)
+			errorMsg := fmt.Sprintf("Instance not found: %s", req.InstanceName)
+			if req.Zone != "" {
+				errorMsg += fmt.Sprintf(" (Checked %s and searched all zones)", req.Zone)
+			}
+			status.ConsumptionStatus = errorMsg
 			return status, nil
 		}
 	}
 
-	// 2. Check Spot Status
+	// Check Spot Status
+
 	isSpot := false
 	status.ProvisioningModel = "STANDARD VM"
 	if instance.Scheduling != nil {
@@ -458,7 +465,7 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 		}
 	}
 
-	// 3. Check Reservation Status
+	// Check Reservation Status
 	if isSpot {
 		status.ReservationAffinity = "None (Spot VM)"
 		status.ConsumptionStatus = "Not consuming (Spot VMs cannot use reservations)"
@@ -488,19 +495,22 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 		case "ANY_RESERVATION":
 			status.ReservationAffinity = "Automatic (Any matching reservation)"
 			foundMatchName := ""
-			req := service.Reservations.List(projectID, status.Zone)
-			_ = req.Pages(ctx, func(page *compute.ReservationList) error {
+
+			reqRes := service.Reservations.List(projectID, status.Zone)
+
+			_ = reqRes.Pages(ctx, func(page *compute.ReservationList) error {
 				for _, res := range page.Items {
 					if res.SpecificReservationRequired || res.Status != "READY" {
 						continue
 					}
+
 					if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
 						resMachineType := GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
 						instMachineType := GetResourceNameFromURL(instance.MachineType)
 
 						if resMachineType == instMachineType {
 							foundMatchName = res.Name
-							return nil 
+							return nil
 						}
 					}
 				}


### PR DESCRIPTION
This PR implements the check_instance_consumption tool to verify if GCE instances are running as Spot VMs, On-Demand, or consuming specific/automatic reservations. 
The core logic is centralized in genericCore to prevent duplication, enabling both cluster-director-gke-ai and cluster-director-slurm servers to access the functionality.
Leveraging robust auto-discovery to locate instances across zones without requiring explicit user input. 
Orchestration is handled via skills.md to route queries to the appropriate server context, and the implementation has been verified locally.