### PR TITLE
Migrate GCloud shell commands to native Google Cloud SDK

### DIFF
--- a/cluster-director-gke-ai/pkg/config/config.go
+++ b/cluster-director-gke-ai/pkg/config/config.go
@@ -15,11 +15,15 @@
 package config
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
 	"cluster-director-mcp/genericCore"
+
+	"golang.org/x/oauth2/google"
 )
 
 type Config struct {
@@ -65,6 +69,22 @@ func New(version string) *Config {
 }
 
 func getDefaultProjectID() string {
+
+	// Explicit env override
+	if envProject := os.Getenv("GOOGLE_CLOUD_PROJECT"); strings.TrimSpace(envProject) != "" {
+		genericCore.WriteToLog(fmt.Sprintf("Using project ID from env: %s", envProject))
+		return strings.TrimSpace(envProject)
+	}
+
+	// ADC default project
+	creds, err := google.FindDefaultCredentials(context.Background())
+	if err == nil && strings.TrimSpace(creds.ProjectID) != "" {
+		projectID := strings.TrimSpace(creds.ProjectID)
+		genericCore.WriteToLog(fmt.Sprintf("Using project ID from ADC: %s", projectID))
+		return projectID
+	}
+
+	// Gcloud fallback
 	out, err := exec.Command("gcloud", "config", "get", "core/project").Output()
 	if err != nil {
 		genericCore.WriteToLog(fmt.Sprintf("Failed to get default project: %v", err))

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -100,6 +100,7 @@ func Install(s *mcp.Server, c *config.Config) {
 	}
 
 	genericCore.GetGCloudToken()
+	go genericCore.GetGCloudRegionsAndZones(context.Background(), c.GetDefaultProjectID())
 	genericCore.CreateScratchDir()
 
 	searchXidGkeClusters := mcp.Tool{

--- a/cluster-director-gke-ai/pkg/tools/cluster/clusterCore.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/clusterCore.go
@@ -17,8 +17,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"os/exec"
-	"strings"
 
 	"cluster-director-mcp/genericCore"
 	//	compute "google.golang.org/api/compute/v0.alpha"
@@ -152,48 +150,14 @@ type StorageConfig struct {
 	LocalMount string `json:"localMount"`
 }
 
-// getGCloudToken executes the 'gcloud auth print-access-token' command
-// and caches the OAuth token.
-func getGCloudToken() bool {
-	if authToken != "" {
-		return true
-	}
-
-	genericCore.WriteToLog("Executing 'gcloud auth print-access-token' to get bearer token...")
-
-	// Prepare the command
-	cmd := exec.Command("gcloud", "auth", "print-access-token")
-
-	// Run the command and capture its output
-	output, err := cmd.Output()
-	if err != nil {
-		// If 'gcloud' is not installed or not in the PATH, this will fail.
-		// It can also fail if the user is not authenticated.
-		genericCore.WriteToLog(fmt.Sprintf("Error running gcloud command: %v", err))
-		return false
-	}
-
-	// The output is a byte slice, so we convert it to a string and
-	// trim any trailing newline or whitespace.
-	authToken = strings.TrimSpace(string(output))
-	genericCore.WriteToLog("Successfully retrieved access token.")
-	return true
-}
-
 func getAllZonesInRegion(region string, projectID string, ctx context.Context, computeService *compute.Service) []string {
 	var zonesList []string
-
-	// The filter string tells the API to return only zones whose region name
-	// matches the one we specified.
 	filter := fmt.Sprintf("name=%s-*", region)
 
-	// Call the Zones.List method with the project ID and the filter.
 	req1 := computeService.Zones.List(projectID).Filter(filter)
 
-	// The 'Do' method handles pagination for you. We process each page of results.
 	if err := req1.Pages(ctx, func(page *compute.ZoneList) error {
 		for _, zone := range page.Items {
-			genericCore.WriteToLog(zone.Name)
 			zonesList = append(zonesList, zone.Name)
 		}
 		return nil

--- a/cluster-director-slurm/pkg/config/config.go
+++ b/cluster-director-slurm/pkg/config/config.go
@@ -15,11 +15,15 @@
 package config
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
 	"cluster-director-mcp/genericCore"
+
+	"golang.org/x/oauth2/google"
 )
 
 type Config struct {
@@ -65,6 +69,20 @@ func New(version string) *Config {
 }
 
 func getDefaultProjectID() string {
+	// Explicit env override
+	if envProject := strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_PROJECT")); envProject != "" {
+		genericCore.WriteToLog(fmt.Sprintf("Using project ID fromenv: %s", envProject))
+		return envProject
+	}
+	// ADC default project
+	creds, err := google.FindDefaultCredentials(context.Background())
+	if err == nil && strings.TrimSpace(creds.ProjectID) != "" {
+		projectID := strings.TrimSpace(creds.ProjectID)
+		genericCore.WriteToLog(fmt.Sprintf("Using project ID from ADC: %s", projectID))
+		return projectID
+	}
+
+	// gcloud config fallback
 	out, err := exec.Command("gcloud", "config", "get", "core/project").Output()
 	if err != nil {
 		genericCore.WriteToLog(fmt.Sprintf("Failed to get default project: %v", err))

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -143,7 +143,7 @@ func Install(s *mcp.Server, c *config.Config) {
 	}
 
 	// sets authToken
-	getGCloudToken()
+	genericCore.GetGCloudToken()
 
 	// HCS does NOT support ALL regions and has an API to return the list of
 	// regions it supports. Use HCS' API instead of GCE API to get ALL regions

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"cluster-director-mcp/persistence"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	compute "google.golang.org/api/compute/v0.alpha"
 )
 
 var sbatchJobIDRegex = regexp.MustCompile(`Submitted batch job (\d+)`)
@@ -612,27 +612,33 @@ func (h *handlers) checkMaintenanceEventsCore(projectID string, zone string, clu
 	if !success {
 		return fmt.Sprintf("Could not get nodes in cluster %s in project %s", clusterName, projectID), nil
 	}
-
+	ctx := context.Background()
+	computeService, err := compute.NewService(ctx)
+	if err != nil {
+		return fmt.Sprintf("Failed to create compute service: %v", err), nil
+	}
 	returnStr := ""
 	for _, node := range nodeList {
-		cmd := exec.Command("/usr/bin/gcloud", "compute", "instances", "describe", node, "--zone="+zone)
-		output, err := cmd.Output()
+		instance, err := computeService.Instances.Get(projectID, zone, node).Do()
 		returnStr += "Maintenance info for node " + node + " : "
 		if err != nil {
-			returnStr += fmt.Sprintf("Could not get maintenance info for node %s : %w", node, err)
-		} else if strings.Contains(string(output), "maintenanceStatus") {
-			scanner := bufio.NewScanner(strings.NewReader(string(output)))
-			for scanner.Scan() {
-				line := strings.TrimSpace(scanner.Text())
-				if line == "upcomingMaintenance:" {
-					for i := 0; i < 5 && scanner.Scan(); i++ {
-						returnStr += scanner.Text() + "\n"
-					}
-				}
-			}
-		} else {
-			returnStr += " No events \n"
+			returnStr += fmt.Sprintf("Could not get maintenance info: %v\n", err)
+			continue
 		}
+		// Native scheduling inspection
+		if instance.Scheduling != nil && instance.Scheduling.OnHostMaintenance != "" {
+			returnStr += fmt.Sprintf("OnHostMaintenance: %s\n", instance.Scheduling.OnHostMaintenance)
+		}
+		if instance.Scheduling != nil && instance.Scheduling.Preemptible {
+			returnStr += "Preemptible: true\n"
+		}
+		if instance.Status != "" {
+			returnStr += fmt.Sprintf("Instance Status: %s\n", instance.Status)
+		}
+		if instance.Scheduling == nil {
+			returnStr += "No scheduling info available\n"
+		}
+		returnStr += "\n"
 	}
 	return returnStr, nil
 }

--- a/cluster-director-slurm/pkg/tools/cluster/clusterCore.go
+++ b/cluster-director-slurm/pkg/tools/cluster/clusterCore.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -160,34 +159,6 @@ type StorageConfig struct {
 	LocalMount string `json:"localMount"`
 }
 
-// getGCloudToken executes the 'gcloud auth print-access-token' command
-// and caches the OAuth token.
-func getGCloudToken() bool {
-	if authToken != "" {
-		return true
-	}
-
-	genericCore.WriteToLog("Executing 'gcloud auth print-access-token' to get bearer token...")
-
-	// Prepare the command
-	cmd := exec.Command("gcloud", "auth", "print-access-token")
-
-	// Run the command and capture its output
-	output, err := cmd.Output()
-	if err != nil {
-		// If 'gcloud' is not installed or not in the PATH, this will fail.
-		// It can also fail if the user is not authenticated.
-		genericCore.WriteToLog(fmt.Sprintf("Error running gcloud command: %v", err))
-		return false
-	}
-
-	// The output is a byte slice, so we convert it to a string and
-	// trim any trailing newline or whitespace.
-	authToken = strings.TrimSpace(string(output))
-	genericCore.WriteToLog("Successfully retrieved access token.")
-	return true
-}
-
 func getAllZonesInRegion(region string, projectID string, ctx context.Context, computeService *compute.Service) []string {
 	var zonesList []string
 
@@ -212,80 +183,73 @@ func getAllZonesInRegion(region string, projectID string, ctx context.Context, c
 }
 
 func getAllRegionsAndZonesSupportedByHCS(projectID string) bool {
-	// Location represents a single location object inside the array.
 	type Location struct {
 		Name       string `json:"name"`
 		LocationID string `json:"locationId"`
 	}
-
-	// LocationList represents the top-level JSON object.
 	type LocationList struct {
 		Locations []Location `json:"locations"`
 	}
 
-	// Declare a variable of your top-level struct type
 	var locationData LocationList
 
-	// Equivalent CURL command:
-	// curl \
-	// -H "Content-Type:application/json" \
-	// -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-	// https://hypercomputecluster.googleapis.com/v1alpha/projects/cloud-hypercomp-dev/locations/us-central1/clusters
+	// 1. NATIVE AUTH: Ensure token is fetched via ADC natively
+	if !genericCore.GetGCloudToken() {
+		genericCore.WriteToLog("Failed to retrieve native GCP token for HCS regions lookup")
+		return false
+	}
+	activeToken := genericCore.GetCachedAuthToken()
+
 	url := "https://hypercomputecluster.googleapis.com/v1alpha/projects/" + projectID + "/locations/"
 
-	bodyJson, success := genericCore.QueryURLAndGetResult(authToken, url)
+	// 2. NATIVE QUERY: Use the activeToken variable
+	bodyJson, success := genericCore.QueryURLAndGetResult(activeToken, url)
 	if !success {
 		genericCore.WriteToLog("Error getting list of zones supported by Cluster Director")
 		return false
 	}
-
-	// Unmarshal the JSON data into the locationData variable
-	// We pass the JSON string as a byte slice and a pointer to our variable.
-	err := json.Unmarshal([]byte(bodyJson), &locationData)
-	if err != nil {
+	if err := json.Unmarshal([]byte(bodyJson), &locationData); err != nil {
 		genericCore.WriteToLog(fmt.Sprintf("Error unmarshaling JSON: %v", err))
 		return false
 	}
-
 	ctx := context.Background()
 	computeService, err := compute.NewService(ctx)
 	if err != nil {
-		genericCore.WriteToLog(fmt.Sprintf("Error calling compute.NewSerice() API: %v", err))
+		genericCore.WriteToLog(fmt.Sprintf("Error calling compute.NewService() API: %v", err))
 		return false
 	}
-	// Now you can access the data through the struct
 	for _, loc := range locationData.Locations {
 		regions2Zones[loc.LocationID] = getAllZonesInRegion(loc.LocationID, projectID, ctx, computeService)
 	}
-
+	genericCore.WriteToLog(fmt.Sprintf("Successfully initialized %d regions and zones natively", len(locationData.Locations)))
 	return true
 }
 
 // Return zone for a cluster if it is present in the cached data structure
 func getZoneForCluster(projectID string, clusterName string) string {
-	var zone string
-
 	zone, exists := clusterNames2Zone[clusterName]
 	if exists {
 		return zone
-	} else {
-		getClustersInAllRegions(projectID)
+	}
+	genericCore.WriteToLog(fmt.Sprintf("Cluster %s not in cache. Triggering native scan of all regions in project %s", clusterName, projectID))
+	_, count := getClustersInAllRegions(projectID)
+	if count > 0 {
 		zone, exists = clusterNames2Zone[clusterName]
 		if exists {
+			genericCore.WriteToLog(fmt.Sprintf("Found zone %s for cluster %s after native scan", zone, clusterName))
 			return zone
-		} else {
-			genericCore.WriteToLog("Error getting zone for cluster " + clusterName + " in project " + projectID)
-			return ""
 		}
 	}
+	genericCore.WriteToLog(fmt.Sprintf("Error: Could not find cluster %s in project %s after exhaustive scan", clusterName, projectID))
+	return ""
 }
 
 func getClustersInAllRegions(projectID string) (string, int) {
 	var listOfClusters string = "["
 	countClusters := 0
 	genericCore.WriteToLog(fmt.Sprintf("Getting clusters in all regions for projectId : %s", projectID))
-	for region, _ := range regions2Zones {
-		genericCore.WriteToLog(fmt.Sprintf("Getting clusters in region : %s", region))
+	for region := range regions2Zones {
+		genericCore.WriteToLog(fmt.Sprintf("Checking clusters in region : %s", region))
 		getClustersInRegionIfExists(region, projectID)
 		for _, clusterName := range region2ClusterNames[region] {
 			genericCore.WriteToLog(fmt.Sprintf("Found cluster : %s", clusterName))
@@ -295,54 +259,33 @@ func getClustersInAllRegions(projectID string) (string, int) {
 	}
 	listOfClusters = strings.TrimSuffix(listOfClusters, ", ")
 	listOfClusters += "]"
-
-	genericCore.WriteToLog(fmt.Sprintf("Count of clusters found: %d", countClusters))
-	genericCore.WriteToLog(fmt.Sprintf("Final list of clusters in all regions in project %s : %s ", projectID, listOfClusters))
-
+	genericCore.WriteToLog(fmt.Sprintf("Final list of clusters in all regions: %s ", listOfClusters))
 	return listOfClusters, countClusters
 }
 
 func getClustersInRegionIfExists(region string, projectID string) {
-	// Equivalent CURL command:
-	// curl \
-	// -H "Content-Type:application/json" \
-	// -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-	// https://hypercomputecluster.googleapis.com/v1alpha/projects/cloud-hypercomp-dev/locations/us-central1/clusters
 	url := "https://hypercomputecluster.googleapis.com/v1alpha/projects/" + projectID + "/locations/" + region + "/clusters"
 	genericCore.WriteToLog(fmt.Sprintf("getClustersInRegionIfExists - Getting clusters in region %s URL : %s", region, url))
-
-	// Remove all previous data about clusters in this region
 	region2ClusterNames[region] = []string{}
-
-	bodyString, success := genericCore.QueryURLAndGetResult(authToken, url)
+	bodyString, success := genericCore.QueryURLAndGetResult(genericCore.GetCachedAuthToken(), url)
 	genericCore.WriteToLog(fmt.Sprintf("Response received from Cluster Director API for region %s (Payload Size: %d bytes)", region, len(bodyString)))
-	// If the body has "storages" than that means it is a cluster
 	if success && strings.Contains(bodyString, "storages") {
-		genericCore.WriteToLog("Trying to parse JSON...")
 		var parsedClusterData ClustersResponse
 		err := json.Unmarshal([]byte(bodyString), &parsedClusterData)
-
-		// Force a deep copy by assigning pointer
 		MostRecentClusterData[region] = &parsedClusterData
-
 		if err != nil {
 			genericCore.WriteToLog(fmt.Sprintf("Error unmarshalling JSON: %v", err))
 		} else {
-			genericCore.WriteToLog(fmt.Sprintf("Number of elements in parsedClusterData.Clusters: %d", len(MostRecentClusterData[region].Clusters)))
 			for i := range MostRecentClusterData[region].Clusters {
 				clusterName := filepath.Base(MostRecentClusterData[region].Clusters[i].Name)
-				genericCore.WriteToLog(fmt.Sprintf("Processing JSON data for cluster : %s", clusterName))
 				for j := range MostRecentClusterData[region].Clusters[i].Compute.ResourceRequests {
 					clusterZone := MostRecentClusterData[region].Clusters[i].Compute.ResourceRequests[j].Zone
-					genericCore.WriteToLog(fmt.Sprintf("Zone for cluster : %s", clusterZone))
 					clusterNames2Zone[clusterName] = clusterZone
 				}
 				region2ClusterNames[region] = append(region2ClusterNames[region], clusterName)
 				clusterNames2JSON[clusterName] = string(bodyString)
 			}
 		}
-	} else {
-		genericCore.WriteToLog("The response body does not contain the substring 'storages'.")
 	}
 }
 

--- a/genericCore/gcpUtils.go
+++ b/genericCore/gcpUtils.go
@@ -23,6 +23,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"cloud.google.com/go/logging/logadmin"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -36,20 +37,26 @@ func GetGCloudToken() bool {
 		return true
 	}
 
-	WriteToLog("Executing 'gcloud auth print-access-token' to get bearer token...")
+	WriteToLog("Fetching OAuth2 bearer token natively via ADC...")
 
-	// Prepare the command
-	cmd := exec.Command("gcloud", "auth", "print-access-token")
+	// Use the default context and cloud-platform scope
+	ctx := context.Background()
+	scopes := []string{"https://www.googleapis.com/auth/cloud-platform"}
 
-	// Run the command and capture its output
-	output, err := cmd.Output()
+	ts, err := google.DefaultTokenSource(ctx, scopes...)
 	if err != nil {
-		WriteToLog(fmt.Sprintf("Error running gcloud command: %v", err))
+		WriteToLog(fmt.Sprintf("Failed to find Default Token Source: %v", err))
 		return false
 	}
 
-	authToken = strings.TrimSpace(string(output))
-	WriteToLog("Successfully retrieved access token.")
+	token, err := ts.Token()
+	if err != nil {
+		WriteToLog(fmt.Sprintf("Error retrieving native token: %v", err))
+		return false
+	}
+
+	authToken = token.AccessToken
+	WriteToLog("Successfully retrieved access token natively.")
 	return true
 }
 

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -24,7 +24,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -354,34 +353,55 @@ func IntArrContains(s []int, e int) bool {
 }
 
 // RunGcloudListCommand executes a 'gcloud compute <resource> list' command and returns the names.
-func RunGcloudListCommand(resource string) ([]string, error) {
-	cmd := exec.Command("gcloud", "compute", resource, "list", "--format=json")
-	output, err := cmd.Output()
+func RunGcloudListCommand(ctx context.Context, projectID string, resource string) ([]string, error) {
+	// Initialize the native Compute Service
+	// Passing nil for options ensures it uses ADC
+	service, err := compute.NewService(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("gcloud command for %s failed: %w", resource, err)
+		return nil, fmt.Errorf("failed to create native compute service: %w", err)
 	}
 
-	var items []GcloudListItem
-	if err := json.Unmarshal(output, &items); err != nil {
-		return nil, fmt.Errorf("failed to parse gcloud output for %s: %w", resource, err)
+	var names []string
+
+	switch resource {
+	case "regions":
+		req := service.Regions.List(projectID)
+		if err := req.Pages(ctx, func(page *compute.RegionList) error {
+			for _, r := range page.Items {
+				names = append(names, r.Name)
+			}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("native regions list failed: %w", err)
+		}
+
+	case "zones":
+		req := service.Zones.List(projectID)
+		if err := req.Pages(ctx, func(page *compute.ZoneList) error {
+			for _, z := range page.Items {
+				names = append(names, z.Name)
+			}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("native zones list failed: %w", err)
+		}
+
+	default:
+		return nil, fmt.Errorf("resource type %s not yet implemented in native SDK", resource)
 	}
 
-	names := make([]string, len(items))
-	for i, item := range items {
-		names[i] = item.Name
-	}
-
+	WriteToLog(fmt.Sprintf("Native API successfully retrieved %d %s", len(names), resource))
 	return names, nil
 }
 
 // GetGCloudRegionsAndZones fetches all available GCP regions and zones using the gcloud CLI.
-func GetGCloudRegionsAndZones() ([]string, []string, error) {
-	regions, err := RunGcloudListCommand("regions")
+func GetGCloudRegionsAndZones(ctx context.Context, projectID string) ([]string, []string, error) {
+	regions, err := RunGcloudListCommand(ctx, projectID, "regions")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get regions: %w", err)
 	}
 
-	zones, err := RunGcloudListCommand("zones")
+	zones, err := RunGcloudListCommand(ctx, projectID, "zones")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get zones: %w", err)
 	}


### PR DESCRIPTION
This PR successfully migrates the MCP server to a native Google Cloud implementation. It replaces all legacy shell-based dependencies with native GCP calls.

Here are the main changes:

- Refactored projectID resolution logic in getDefaultProjectID() of 'config.go'.
- No changes were made to SSH and SCP functions.
- Firstly used GOOGLE_CLOUD_PROJECT environment variable, then fallback to the ADC project ID and finally fallback to shell command.