### PR TITLE
Cleanup and refactored searchLogsMCP implementation

### DIFF
--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -15,25 +15,18 @@
 package cluster
 
 import (
+	"cluster-director-mcp/cluster-director-gke-ai/pkg/config"
+	"cluster-director-mcp/genericCore"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"cluster-director-mcp/cluster-director-gke-ai/pkg/config"
-	"cluster-director-mcp/genericCore"
-
-	"cloud.google.com/go/logging"
-	"cloud.google.com/go/logging/logadmin"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"google.golang.org/api/iterator"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type SearchLogsRequest struct {
@@ -46,8 +39,8 @@ type SearchLogsRequestWithoutCluster struct {
 }
 
 type SearchLogsRequestXidGkeClusters struct {
-	StartDate string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
-	EndDate   string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	StartDate   string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate     string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
 	JobName     string `json:"JobName,omitempty" jsonschema:"description=GKE Job Name whose logs we should search"`
 	ClusterName string `json:"ClusterName,omitempty" jsonschema:"description=GKE cluster Name whose logs we should search"`
 }
@@ -83,24 +76,13 @@ type handlers struct {
 	c *config.Config
 }
 
-type LogSearchType int
-
-const (
-	AreNCCLDebugLogsEnabled                  LogSearchType = iota // 0
-	WereThereNCCLWarnMessages                                     // 1
-	WereThereNCCLErrorMessages                                    // 2
-	WereThereXidFailureMessagesInGkeCluster                       // 3
-	WereThereXidFailureMessagesInGkePod                           // 3
-	WereThereXidFailureMessagesInGceInstance                      // 3
-)
-
 func Install(s *mcp.Server, c *config.Config) {
 	h := &handlers{
 		c: c,
 	}
 
 	// sets authToken
-	getGCloudToken()
+	genericCore.GetGCloudToken()
 
 	// A place where we keep temporary files
 	genericCore.CreateScratchDir()
@@ -141,7 +123,7 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchXidGkeClusters,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestXidGkeClusters) (*mcp.CallToolResult, SearchLogsResponse, error) {
-			result, foundsIssues, err := h.searchLogsMCP(ctx, &req, WereThereXidFailureMessagesInGkeCluster)
+			result, foundsIssues, err := h.searchLogsMCP(ctx, &req, genericCore.WereThereXidFailureMessagesInGkeCluster)
 			if foundsIssues {
 				result += ". Your job is possibly slow because we found Xid errors on the nodes running it"
 			}
@@ -193,7 +175,7 @@ func Install(s *mcp.Server, c *config.Config) {
 
 }
 
-func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequestXidGkeClusters, searchType LogSearchType) (string, bool, error) {
+func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequestXidGkeClusters, searchType genericCore.LogSearchType) (string, bool, error) {
 	projectID := h.c.GetDefaultProjectID()
 	if projectID == "" {
 		return "Could not determine GCP project. Please run: gcloud config set project \"your-project-name\" and restart the AI Assistant", false, nil
@@ -205,7 +187,7 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 	var numberOfDays int
 	var startDateValid, endDateValid bool
 
-	if searchType == WereThereXidFailureMessagesInGkeCluster {
+	if searchType == genericCore.WereThereXidFailureMessagesInGkeCluster {
 
 		startDateStr = request.StartDate
 		startDate, startDateValid = genericCore.ParseTime(startDateStr)
@@ -232,17 +214,17 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 	startTimeFromLookBack := time.Now().Add(-lookbackDuration).Format(time.RFC3339)
 	filter := ""
 
-	if searchType == AreNCCLDebugLogsEnabled {
+	if searchType == genericCore.AreNCCLDebugLogsEnabled {
 		filter = fmt.Sprintf(`resource.type="k8s_container" AND timestamp >= "%s" AND (textPayload="*NCCL*" OR jsonPayload.message="*NCCL*")`, startTimeFromLookBack)
-	} else if searchType == WereThereNCCLWarnMessages {
+	} else if searchType == genericCore.WereThereNCCLWarnMessages {
 		filter = fmt.Sprintf(`resource.type="k8s_container" AND timestamp >= "%s" AND (textPayload:"*NCCL WARN*" OR jsonPayload.message:"*NCCL WARN*")`, startTimeFromLookBack)
-	} else if searchType == WereThereNCCLErrorMessages {
+	} else if searchType == genericCore.WereThereNCCLErrorMessages {
 		filter = fmt.Sprintf(`resource.type="k8s_container" AND timestamp >= "%s" AND (textPayload:"*NCCL ERROR*" OR jsonPayload.message:"*NCCL ERROR*")`, startTimeFromLookBack)
-	} else if searchType == WereThereXidFailureMessagesInGkeCluster {
+	} else if searchType == genericCore.WereThereXidFailureMessagesInGkeCluster {
 		filter = `resource.type="k8s_pod" AND jsonPayload.reason="Scheduled" `
 		filter += fmt.Sprintf(` AND resource.labels.cluster_name="%s" `, clusterName)
 		filter += fmt.Sprintf(` AND (resource.labels.pod_name:"%s" OR labels."k8s-pod/job-name"="%s") `, jobName, jobName)
-	} else if searchType == WereThereXidFailureMessagesInGkePod {
+	} else if searchType == genericCore.WereThereXidFailureMessagesInGkePod {
 		filter = fmt.Sprintf(`(textPayload:"NVRM: Xid" OR jsonPayload.message:"NVRM: Xid") `)
 		if instanceName != "" {
 			//filter += fmt.Sprintf(` AND resource.type="gce_instance" AND resource.labels.instance_id="%s" `, instanceName)
@@ -274,14 +256,21 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 	}
 
 	// hard coded 128 max results of now
-	retMesgStr, returnResults, logSearchSuccess := searchLogsCore(h, ctx, projectID, filter, 128, searchType)
+	retMesgStr, returnResults, logSearchSuccess := genericCore.SearchLogsCore(ctx, projectID, filter, 128, searchType)
 
 	if !logSearchSuccess {
 		return retMesgStr, false, nil
 	}
 
-	if searchType == WereThereXidFailureMessagesInGkeCluster {
+	if searchType == genericCore.WereThereXidFailureMessagesInGkeCluster {
 		if logSearchSuccess {
+			// Each array in returnResults has podName, "", location, xidErr
+			// We need to fill in instanceName by calling getGceInstanceForPod
+			for i := range returnResults {
+				if returnResults[i][0] != "" { // if podName is present
+					returnResults[i][1] = getGceInstanceForPod(returnResults[i][0])
+				}
+			}
 			// Each array in returnResults has podName, instName, location, xidErr
 			retMesgStr = fmt.Sprintf("searchLogsMCP.4444 got %d results for Pods", len(returnResults))
 			genericCore.WriteToLog("Success: " + retMesgStr + " but no Xid errors")
@@ -292,19 +281,19 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 				return doInstanceLogsHaveXidErrors(returnResults, h, ctx, projectID), false, nil
 			}
 		}
-	} else if searchType == AreNCCLDebugLogsEnabled {
+	} else if searchType == genericCore.AreNCCLDebugLogsEnabled {
 		if logSearchSuccess {
 			retMesgStr += "NCCL Debug is enabled\n"
 		} else {
 			retMesgStr = "NCCL Debug Info NOT found"
 		}
-	} else if searchType == WereThereNCCLWarnMessages {
+	} else if searchType == genericCore.WereThereNCCLWarnMessages {
 		if logSearchSuccess {
 			retMesgStr += "NCCL WARN messages were found\n"
 		} else {
 			retMesgStr = "NCCL WARN messages NOT found"
 		}
-	} else if searchType == WereThereNCCLErrorMessages {
+	} else if searchType == genericCore.WereThereNCCLErrorMessages {
 		if logSearchSuccess {
 			retMesgStr += "NCCL ERROR messages found.\n"
 		} else {
@@ -326,7 +315,7 @@ func doInstanceLogsHaveXidErrors(searchResults [][]string, h *handlers, ctx cont
 		}
 	}
 
-	resultStr, xidResults, success := searchLogsCore(h, ctx, projectID, filter, 1, WereThereXidFailureMessagesInGceInstance)
+	resultStr, xidResults, success := genericCore.SearchLogsCore(ctx, projectID, filter, 1, genericCore.WereThereXidFailureMessagesInGceInstance)
 
 	if success {
 		t := fmt.Sprintf("Found %v Xid errors in %v GCE instances", len(xidResults), len(searchResults))
@@ -334,57 +323,6 @@ func doInstanceLogsHaveXidErrors(searchResults [][]string, h *handlers, ctx cont
 	} else {
 		return resultStr
 	}
-}
-
-func searchLogsCore(h *handlers, ctx context.Context, projectID string, filter string, maxResults int, searchType LogSearchType) (string, [][]string, bool) {
-	genericCore.WriteToLog("-------------------searchLogsCore()-------------------")
-
-	client, err := logadmin.NewClient(ctx, projectID)
-	defer client.Close()
-	if err != nil {
-		genericCore.WriteToLog("Could not create logging client")
-		return fmt.Sprintf("Could not create logging client: %v", err), nil, false
-	}
-
-	it := client.Entries(ctx, logadmin.Filter(filter))
-
-	countResults := 0
-	// This tells the GCP Server "only send me 1 item per page"
-	//it.PageInfo().MaxSize = 1
-
-	var searchResults [][]string
-	//searchSuccess := true
-	// Iterate through the logs
-	var podName, payload, location, xidErr, instName string
-
-	for {
-		entry, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			//searchSuccess = false
-			return fmt.Sprintf("Could not iterate over search results: %v", err), nil, false
-		}
-
-		payload = getPayloadString(entry)
-		podName = entry.Resource.Labels["pod_name"]
-		location = entry.Resource.Labels["location"]
-
-		if searchType == WereThereXidFailureMessagesInGkeCluster {
-			xidErr = parseXidNumber(payload)
-			instName = getGceInstanceForPod(podName)
-			searchResults = append(searchResults, []string{podName, instName, location, xidErr})
-		} else {
-			searchResults = append(searchResults, []string{payload})
-		}
-
-		countResults++
-		if countResults > maxResults {
-			break // Found positive confirmation, stop scanning
-		}
-	}
-	return "Found Xid Errors", searchResults, true
 }
 
 func getGceInstanceForPod(podName string) string {
@@ -408,45 +346,6 @@ func getGceInstanceForPod(podName string) string {
 	// The ProviderID format is: gce://project-id/zone/instance-name
 	//fmt.Printf("GCE Provider ID: %s\n", node.Spec.ProviderID)
 	return nodeName
-}
-
-func parseXidNumber(logLine string) string {
-	//logLine := "Jan 14 22:15:17 xxxxxx-nodeset1-40 kernel: [2437042.862382] NVRM: Xid (PCI:0000:84:00): 95, Uncontained: FBHUB. RST: Yes"
-
-	// 1. Find the anchor "): "
-	// "after" will be "95, Uncontained: FBHUB. RST: Yes"
-	_, after, found := strings.Cut(logLine, "): ")
-
-	if found {
-		// 2. Cut at the comma to get just the number
-		// "numberStr" will be "95"
-		numberStr, _, _ := strings.Cut(after, ",")
-
-		// 3. Convert to int
-		//xid, _ := strconv.Atoi(strings.TrimSpace(numberStr))
-
-		return numberStr
-	}
-	return ""
-}
-
-// Helper to extract string content from either text or JSON payloads
-func getPayloadString(entry *logging.Entry) string {
-	switch p := entry.Payload.(type) {
-	case string:
-		return p
-	case *structpb.Struct: // Requires "google.golang.org/protobuf/types/known/structpb"
-		// If using structured logging, the actual message is usually in a "message" or "log" field
-		if val, ok := p.Fields["message"]; ok {
-			return val.GetStringValue()
-		}
-		if val, ok := p.Fields["log"]; ok {
-			return val.GetStringValue()
-		}
-		return p.String() // Fallback: dump the whole struct
-	default:
-		return fmt.Sprintf("%v", p)
-	}
 }
 
 // Implementation

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -15,18 +15,21 @@
 package cluster
 
 import (
-	"cluster-director-mcp/cluster-director-gke-ai/pkg/config"
-	"cluster-director-mcp/genericCore"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"cluster-director-mcp/cluster-director-gke-ai/pkg/config"
+	"cluster-director-mcp/genericCore"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type SearchLogsRequest struct {
@@ -43,13 +46,15 @@ type SearchLogsRequestXidGkeClusters struct {
 	EndDate     string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
 	JobName     string `json:"JobName,omitempty" jsonschema:"description=GKE Job Name whose logs we should search"`
 	ClusterName string `json:"ClusterName,omitempty" jsonschema:"description=GKE cluster Name whose logs we should search"`
+	MaxResults  int    `json:"MaxResults,omitempty" jsonschema:"default=100,description=Maximum number of log entries to retrieve"`
 }
 
 type SearchLogsRequestXidGkePods struct {
-	StartDate string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
-	EndDate   string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
-	JobName   string `json:"JobName,omitempty" jsonschema:"description=Name of the GKE Job whose logs we should search"`
-	PodName   string `json:"PodName,omitempty" jsonschema:"description=Name of the pod whose logsr5 we should search"`
+	StartDate  string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate    string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	JobName    string `json:"JobName,omitempty" jsonschema:"description=Name of the GKE Job whose logs we should search"`
+	PodName    string `json:"PodName,omitempty" jsonschema:"description=Name of the pod whose logsr5 we should search"`
+	MaxResults int    `json:"MaxResults,omitempty" jsonschema:"default=100,description=Maximum number of log entries to retrieve"`
 }
 
 type SearchLogsRequestXidGce struct {
@@ -59,6 +64,7 @@ type SearchLogsRequestXidGce struct {
 	InstanceName string `json:"InstanceName,omitempty" jsonschema:"description=Name of the instance whose logs we should search"`
 	JobName      string `json:"JobName,omitempty" jsonschema:"description=Name of the GKE Job whose logs we should search"`
 	PodName      string `json:"PodName,omitempty" jsonschema:"description=Name of the pod whose logsr5 we should search"`
+	MaxResults   int    `json:"MaxResults,omitempty" jsonschema:"default=100,description=Maximum number of log entries to retrieve"`
 }
 
 type SearchLogsResponse struct {
@@ -114,6 +120,10 @@ func Install(s *mcp.Server, c *config.Config) {
 				"ClusterName": map[string]interface{}{
 					"type":        "string",
 					"description": "Name of the GKE cluster whose log to search. Required argument.",
+				},
+				"MaxResults": map[string]interface{}{
+					"type":        "number",
+					"description": "Maximum number of log entries to retrieve. Defaults to 100. Optional argument.",
 				},
 			},
 			"required": []string{"ClusterName", "JobName"},
@@ -209,8 +219,6 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 	lookbackDuration := time.Duration(numberOfDays) * 24 * time.Hour // How far back to look
 
 	// Build the filter for GKE logs
-	// We look for 'k8s_container' resources.
-	// We specifically filter for the string "NCCL" to reduce the data we fetch.
 	startTimeFromLookBack := time.Now().Add(-lookbackDuration).Format(time.RFC3339)
 	filter := ""
 
@@ -227,18 +235,15 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 	} else if searchType == genericCore.WereThereXidFailureMessagesInGkePod {
 		filter = fmt.Sprintf(`(textPayload:"NVRM: Xid" OR jsonPayload.message:"NVRM: Xid") `)
 		if instanceName != "" {
-			//filter += fmt.Sprintf(` AND resource.type="gce_instance" AND resource.labels.instance_id="%s" `, instanceName)
 			filter += fmt.Sprintf(` AND resource.type="gce_instance" AND labels."compute.googleapis.com/resource_name"="%s" `, instanceName)
 		} else if podName != "" || jobName != "" {
 			filter += ` resource.type="k8s_container" `
 			if jobName != "" {
 				filter += fmt.Sprintf(` AND (labels."k8s-pod/job-name="%s"" OR resource.labels.pod_name:"%s-") `, jobName, jobName)
 			}
-			//
 			if podName != "" {
 				filter += fmt.Sprintf(` AND resource.labels.pod_name="%s"" `, podName)
 			}
-
 			if startDateValid {
 				filter += fmt.Sprintf(` AND timestamp >= "%s" `, startDate.Format("2006-01-02"))
 			}
@@ -255,8 +260,13 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 		}
 	}
 
-	// hard coded 128 max results of now
-	retMesgStr, returnResults, logSearchSuccess := genericCore.SearchLogsCore(ctx, projectID, filter, 128, searchType)
+	// Dynamic fallback for limits
+	limit := request.MaxResults
+	if limit <= 0 {
+		limit = 100
+	}
+
+	retMesgStr, returnResults, logSearchSuccess := genericCore.SearchLogsCore(ctx, projectID, filter, limit, searchType)
 
 	if !logSearchSuccess {
 		return retMesgStr, false, nil
@@ -264,14 +274,16 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 
 	if searchType == genericCore.WereThereXidFailureMessagesInGkeCluster {
 		if logSearchSuccess {
-			// Each array in returnResults has podName, "", location, xidErr
-			// We need to fill in instanceName by calling getGceInstanceForPod
+			// Iterate and fill in GKE specific variables replacing the raw genericCore payload
 			for i := range returnResults {
-				if returnResults[i][0] != "" { // if podName is present
-					returnResults[i][1] = getGceInstanceForPod(returnResults[i][0])
+				if returnResults[i][0] != "" {
+					returnResults[i][1] = getGceInstanceForPod(returnResults[i][0]) // instName
+				}
+				if returnResults[i][3] != "" {
+					returnResults[i][3] = parseXidNumber(returnResults[i][3]) // xidErr
 				}
 			}
-			// Each array in returnResults has podName, instName, location, xidErr
+
 			retMesgStr = fmt.Sprintf("searchLogsMCP.4444 got %d results for Pods", len(returnResults))
 			genericCore.WriteToLog("Success: " + retMesgStr + " but no Xid errors")
 
@@ -305,17 +317,16 @@ func (h *handlers) searchLogsMCP(ctx context.Context, request *SearchLogsRequest
 }
 
 func doInstanceLogsHaveXidErrors(searchResults [][]string, h *handlers, ctx context.Context, projectID string) string {
-
 	filter := ` resource.type="gce_instance"  `
 
 	for _, arr := range searchResults {
-		// podName, instName, location, XidErr
+		// arr[1] corresponds to instName
 		if arr[1] != "" {
 			filter += fmt.Sprintf(` AND labels."compute.googleapis.com/resource_name"="%s" `, arr[1])
 		}
 	}
 
-	resultStr, xidResults, success := genericCore.SearchLogsCore(ctx, projectID, filter, 1, genericCore.WereThereXidFailureMessagesInGceInstance)
+	resultStr, xidResults, success := genericCore.SearchLogsCore(ctx, projectID, filter, 100, genericCore.WereThereXidFailureMessagesInGceInstance)
 
 	if success {
 		t := fmt.Sprintf("Found %v Xid errors in %v GCE instances", len(xidResults), len(searchResults))
@@ -326,7 +337,6 @@ func doInstanceLogsHaveXidErrors(searchResults [][]string, h *handlers, ctx cont
 }
 
 func getGceInstanceForPod(podName string) string {
-	// hard coded fix later
 	namespace := "default"
 
 	// Setup Kubernetes client
@@ -334,18 +344,24 @@ func getGceInstanceForPod(podName string) string {
 	config, _ := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	clientset, _ := kubernetes.NewForConfig(config)
 
-	// 1. Get the Pod object
+	// Get the Pod object
 	pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
 		genericCore.WriteToLog("Could not find instance name for pod " + podName + " . error message: " + fmt.Sprintf("%v", err))
 		return ""
 	}
 
-	nodeName := pod.Spec.NodeName
+	return pod.Spec.NodeName
+}
 
-	// The ProviderID format is: gce://project-id/zone/instance-name
-	//fmt.Printf("GCE Provider ID: %s\n", node.Spec.ProviderID)
-	return nodeName
+func parseXidNumber(logLine string) string {
+	_, after, found := strings.Cut(logLine, "): ")
+
+	if found {
+		numberStr, _, _ := strings.Cut(after, ",")
+		return numberStr
+	}
+	return ""
 }
 
 // Implementation

--- a/cluster-director-gke-ai/pkg/tools/cluster/clusterCore.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/clusterCore.go
@@ -203,3 +203,11 @@ func getAllZonesInRegion(region string, projectID string, ctx context.Context, c
 	}
 	return zonesList
 }
+
+// Instance holds the parsed data for a single machine.
+type Instance struct {
+	Name        string
+	MachineType string
+}
+
+var AllInstancesInProject []Instance

--- a/cluster-director-gke-ai/pkg/tools/cluster/clusterCore.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/clusterCore.go
@@ -203,11 +203,3 @@ func getAllZonesInRegion(region string, projectID string, ctx context.Context, c
 	}
 	return zonesList
 }
-
-// Instance holds the parsed data for a single machine.
-type Instance struct {
-	Name        string
-	MachineType string
-}
-
-var AllInstancesInProject []Instance

--- a/genericCore/gcp_utils.go
+++ b/genericCore/gcp_utils.go
@@ -16,6 +16,7 @@ package genericCore
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -146,4 +147,48 @@ func RunSCP(project string, zone string, srcFile string, destFile string) (strin
 	}
 
 	return filteredSCPOutput, true
+}
+
+// LogSearchType defines the type of log search to perform.
+type LogSearchType int
+
+const (
+	LogSearchTypeUnknown LogSearchType = iota
+	WereThereXidFailureMessagesInGkeCluster
+	WereThereXidFailureMessagesInGkePod
+	AreNCCLDebugLogsEnabled
+	WereThereNCCLWarnMessages
+	WereThereNCCLErrorMessages
+	WereThereXidFailureMessagesInGceInstance // Added to satisfy line 311 in cluster.go
+)
+
+// SearchLogsCore executes a 'gcloud logging read' command using the raw filter built by cluster.go.
+// It returns (message, 2D array of results, success boolean) to match the expected cluster.go signature.
+func SearchLogsCore(ctx context.Context, projectID string, filter string, limit int, searchType LogSearchType) (string, [][]string, bool) {
+	WriteToLog(fmt.Sprintf("Executing log search with filter: %s", filter))
+
+	// 1. Execute gcloud logging read natively using the provided limit and filter
+	cmd := exec.CommandContext(ctx, "gcloud", "logging", "read", filter, "--project="+projectID, fmt.Sprintf("--limit=%d", limit), "--format=json")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		WriteToLog(fmt.Sprintf("SearchLogsCore error: %v, output: %s", err, string(output)))
+		return fmt.Sprintf("Log search failed: %v", err), nil, false
+	}
+
+	logs := string(output)
+
+	// If the JSON response is larger than empty brackets "[]", results were found.
+	found := len(strings.TrimSpace(logs)) > 5
+
+	// 2. Format the 2D array expected by cluster.go
+	// cluster.go expects each row to contain: []string{podName, instanceName, location, logText}
+	var parsedResults [][]string
+	if found {
+		// Supplying a safe default structure to prevent index out-of-bounds panics in cluster.go
+		// Note: A full JSON unmarshaler goes here if exact pod names must be dynamically extracted from the log JSON.
+		parsedResults = append(parsedResults, []string{"unknown-pod", "", "unknown-zone", "xid-error-found"})
+	}
+
+	return "Search completed successfully", parsedResults, found
 }

--- a/genericCore/gcp_utils.go
+++ b/genericCore/gcp_utils.go
@@ -20,6 +20,11 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"cloud.google.com/go/logging"
+	"cloud.google.com/go/logging/logadmin"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var authToken string
@@ -59,13 +64,12 @@ func GetCachedAuthToken() string {
 
 func FilterString(rawSSHOut string, substringsToRemove []string) string {
 	// Remove warning/useless strings from ssh output
-	var b strings.Builder // Use a Builder to efficiently build the new string
+	var b strings.Builder
 	scanner := bufio.NewScanner(strings.NewReader(rawSSHOut))
 	var ignoreLine bool
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// Ignore empty lines
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -81,7 +85,6 @@ func FilterString(rawSSHOut string, substringsToRemove []string) string {
 			continue
 		}
 
-		// do no ignore this line
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
@@ -154,41 +157,74 @@ type LogSearchType int
 
 const (
 	LogSearchTypeUnknown LogSearchType = iota
+	WereThereNCCLWarnMessages
+	WereThereNCCLErrorMessages
 	WereThereXidFailureMessagesInGkeCluster
 	WereThereXidFailureMessagesInGkePod
 	AreNCCLDebugLogsEnabled
-	WereThereNCCLWarnMessages
-	WereThereNCCLErrorMessages
-	WereThereXidFailureMessagesInGceInstance // Added to satisfy line 311 in cluster.go
+	WereThereXidFailureMessagesInGceInstance
 )
 
-// SearchLogsCore executes a 'gcloud logging read' command using the raw filter built by cluster.go.
-// It returns (message, 2D array of results, success boolean) to match the expected cluster.go signature.
-func SearchLogsCore(ctx context.Context, projectID string, filter string, limit int, searchType LogSearchType) (string, [][]string, bool) {
-	WriteToLog(fmt.Sprintf("Executing log search with filter: %s", filter))
+// SearchLogsCore executes a log search using the GCP SDK.
+func SearchLogsCore(ctx context.Context, projectID string, filter string, maxResults int, searchType LogSearchType) (string, [][]string, bool) {
+	WriteToLog("-------------------SearchLogsCore()-------------------")
 
-	// 1. Execute gcloud logging read natively using the provided limit and filter
-	cmd := exec.CommandContext(ctx, "gcloud", "logging", "read", filter, "--project="+projectID, fmt.Sprintf("--limit=%d", limit), "--format=json")
-	output, err := cmd.CombinedOutput()
-
+	client, err := logadmin.NewClient(ctx, projectID)
 	if err != nil {
-		WriteToLog(fmt.Sprintf("SearchLogsCore error: %v, output: %s", err, string(output)))
-		return fmt.Sprintf("Log search failed: %v", err), nil, false
+		WriteToLog("Could not create logging client")
+		return fmt.Sprintf("Could not create logging client: %v", err), nil, false
+	}
+	defer client.Close()
+
+	it := client.Entries(ctx, logadmin.Filter(filter))
+
+	countResults := 0
+	var searchResults [][]string
+
+	for {
+		entry, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Sprintf("Could not iterate over search results: %v", err), nil, false
+		}
+
+		payload := getPayloadString(entry)
+		podName := entry.Resource.Labels["pod_name"]
+		location := entry.Resource.Labels["location"]
+
+		if searchType == WereThereXidFailureMessagesInGkeCluster {
+			// We pass the raw payload back in the 3rd index.
+			// GKE logic will parse the XID and Instance names locally.
+			searchResults = append(searchResults, []string{podName, "", location, payload})
+		} else {
+			searchResults = append(searchResults, []string{payload})
+		}
+
+		countResults++
+		if countResults >= maxResults {
+			break
+		}
 	}
 
-	logs := string(output)
+	return "Found Xid Errors", searchResults, true
+}
 
-	// If the JSON response is larger than empty brackets "[]", results were found.
-	found := len(strings.TrimSpace(logs)) > 5
-
-	// 2. Format the 2D array expected by cluster.go
-	// cluster.go expects each row to contain: []string{podName, instanceName, location, logText}
-	var parsedResults [][]string
-	if found {
-		// Supplying a safe default structure to prevent index out-of-bounds panics in cluster.go
-		// Note: A full JSON unmarshaler goes here if exact pod names must be dynamically extracted from the log JSON.
-		parsedResults = append(parsedResults, []string{"unknown-pod", "", "unknown-zone", "xid-error-found"})
+// Helper to extract string content from either text or JSON payloads
+func getPayloadString(entry *logging.Entry) string {
+	switch p := entry.Payload.(type) {
+	case string:
+		return p
+	case *structpb.Struct:
+		if val, ok := p.Fields["message"]; ok {
+			return val.GetStringValue()
+		}
+		if val, ok := p.Fields["log"]; ok {
+			return val.GetStringValue()
+		}
+		return p.String()
+	default:
+		return fmt.Sprintf("%v", p)
 	}
-
-	return "Search completed successfully", parsedResults, found
 }

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -412,7 +412,7 @@ func FindInstanceInProject(ctx context.Context, service *compute.Service, projec
 					if inst.Name == instanceName {
 						foundInstance = inst
 						foundZone = GetResourceNameFromURL(inst.Zone)
-						return nil 
+						return nil
 					}
 				}
 			}
@@ -533,7 +533,7 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 
 						if resMachineType == instMachineType {
 							foundMatchName = res.Name
-							return nil 
+							return nil
 						}
 					}
 				}


### PR DESCRIPTION
- Relocated SearchLogsCore from the cluster-director-gke-ai/pkg/tools/cluster/cluster.go to genericCore/gcp_utils.go to decouple the logic and allow it to be shared across multiple environments.
