### PR TITLE
Update run.sh for GCE VM compatibility and remove context7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 Interact with Cluster Director in natural language to use, monitor, maintain and benchmark your Clusters.
 
-<img src="https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-director-mcp/release/assets/gemini-cli-screenshot.png" alt="context7 MCP server error" width="600">
 
 ## MCP Context
 
-We install 2 MCP servers as part of this software stallation, they are:
-1. QA-Assistant : An Expert on [AI-Hypercomputer](https://cloud.google.com/ai-hypercomputer/docs/overview) that can answer questions. based on Uses [context7](https://context7.com/) MCP server.
-2. cluster-director-mcp server: Agentic AI-Assistant that can execute tools (listed in MCP Tools section) on behalf of the user.
+We install MCP servers as part of this software stallation, they are:
+1. cluster-director-mcp server: Agentic AI-Assistant that can execute tools (listed in MCP Tools section) on behalf of the user.
 
 ## Installation and Running Cluster Director MCP
 
@@ -23,7 +21,7 @@ Cluster Director MCP Server is intended to be used on Google [Cloud Shell](https
    
 2. git clone https://github.com/GoogleCloudPlatform/cluster-director-mcp.git
 
-3. Run gemini-cli with the necessary extensions (context7 and cluster-director-mcp) installed 
+3. Run gemini-cli with the necessary cluster-director-mcp extensions installed 
 
 ```sh
 cd cluster-director-mcp; ./run.sh
@@ -43,16 +41,6 @@ cd cluster-director-mcp; ./run.sh
 - `show_job_state`: Shows the jobs running in cluster created using Cluster Director.
 - `show_recent_jobs`: Shows the recent jobs that were run on the of cluster.
 
-## Known issues
-
-- **context7 MCP server Known Issues**: Sometimes the context7 MCP server used to fetch documentation on AI-Hypercomputer gets disconnected with the message ["MCP error (context7)"]. 
-
-<img src="https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-director-mcp/release/assets/mcp-error-context7.png" alt="context7 MCP server error" width="400">
-
-The fix is to run the following command in gemini-cli:
-```sh
-/mcp refresh
-```
 
 
 

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -54,7 +54,7 @@ fi
 
 # Check the user has permission to query IAM policy
 echo "----"
-echo "Checking if user $USER has permissions to get IAM policies for their project..."
+echo "Checking if user $USER has permissions to get IAM policies for their project (permission to run: gcloud projects get-iam-policy "$PROJECT_ID") ..."
 if gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten="bindings[].members" \
   --format='table(bindings.role, bindings.members)' \

--- a/run.sh
+++ b/run.sh
@@ -86,7 +86,7 @@ echo "..."
 wait $git_pull_make_pid
 if [ -n "$CDMCP_DEBUG" ]; then
     echo "CDMCP_DEBUG is defined."    
-    gemini --debug --allowed-mcp-server-names context7,cluster-director-mcp "$@"
+    gemini --debug --allowed-mcp-server-names cluster-director-mcp "$@"
 else
-    gemini --allowed-mcp-server-names context7,cluster-director-mcp "$@"
+    gemini --allowed-mcp-server-names cluster-director-mcp "$@"
 fi

--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,7 @@ echo "Syncing Go dependencies..."
 go mod tidy
 if [ $? -ne 0 ]; then
   echo "Error: 'go mod tidy' failed. Please ensure Go is installed on this VM."
+  echo "If Go is already installed, check for lack of disk space (run 'df -h') or network issues."
   exit 1
 fi
 # ------------------------------------------------

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,16 @@ echo "----"
 echo "Updating cluster-director-mcp..."
 (git fetch --all 2>&1 > /dev/null ; git pull 2>&1 > /dev/null ; make -j  2>&1 > /dev/null) &
 git_pull_make_pid=$!
+
+# --- NEW: Go Dependency Management for GCE VMs ---
+echo "----"
+echo "Syncing Go dependencies..."
+go mod tidy
+if [ $? -ne 0 ]; then
+  echo "Error: 'go mod tidy' failed. Please ensure Go is installed on this VM."
+  exit 1
+fi
+# ------------------------------------------------
 
 # Clean scratch
 echo "----"
@@ -44,7 +54,7 @@ fi
 
 # Check the user has permission to query IAM policy
 echo "----"
-echo "Checking if user $USER has permissions to get IAM policies for their project (permission to run: gcloud projects get-iam-policy "$PROJECT_ID") ..."
+echo "Checking if user $USER has permissions to get IAM policies for their project..."
 if gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten="bindings[].members" \
   --format='table(bindings.role, bindings.members)' \
@@ -70,13 +80,13 @@ scripts/installExtensions.py ~/.gemini/settings.json
 
 # Run cluster-director-mcp
 echo "----"
-echo -n "Running  based on gemini-cli version "
+echo -n "Running based on gemini-cli version "
 gemini --version
 echo "..."
 wait $git_pull_make_pid
 if [ -n "$CDMCP_DEBUG" ]; then
     echo "CDMCP_DEBUG is defined."    
-    gemini --debug --allowed-mcp-server-names  context7,cluster-director-mcp "$@"
+    gemini --debug --allowed-mcp-server-names context7,cluster-director-mcp "$@"
 else
-    gemini --allowed-mcp-server-names  context7,cluster-director-mcp "$@"
+    gemini --allowed-mcp-server-names context7,cluster-director-mcp "$@"
 fi

--- a/scripts/installExtensions.py
+++ b/scripts/installExtensions.py
@@ -7,11 +7,11 @@ import shutil
 from pathlib import Path
 
 # Parses a gemini extensions/settings file and adds 
-# cluster-director-mcp and context7 if they are not already present
+# cluster-director-mcp  if it is not already present
 
 def add_extensions_to_gemini_json(file_path):
     """
-    Adds cluster-director-mcp and context7 extensions servers to gemini JSON file.
+    Adds cluster-director-mcp extension servers to gemini JSON file.
     """
 
     print("Processing JSON settings file: " + file_path)
@@ -57,11 +57,6 @@ def add_extensions_to_gemini_json(file_path):
                     "MCP_SERVER_REQUEST_TIMEOUT": "72000000"
                 }
             }
-        if 'context7' not in mcp_servers_dict:
-            print("Adding context7 MCP server")
-            mcp_servers_dict['context7'] = {'httpUrl': "https://mcp.context7.com/mcp"}
-        else:
-            print("context7 MCP server already present")
     else:
         print("mcpServers not present in JSON file, adding both cluster-director-mcp and context7")
         data['mcpServers'] = {
@@ -72,9 +67,6 @@ def add_extensions_to_gemini_json(file_path):
                 "env": {
                     "MCP_SERVER_REQUEST_TIMEOUT": "72000000"
                 }
-            },
-            'context7': {
-                'httpUrl': "https://mcp.context7.com/mcp"
             }
         }
 

--- a/scripts/installExtensions.py
+++ b/scripts/installExtensions.py
@@ -58,7 +58,7 @@ def add_extensions_to_gemini_json(file_path):
                 }
             }
     else:
-        print("mcpServers not present in JSON file, adding both cluster-director-mcp and context7")
+        print("mcpServers not present in JSON file, adding cluster-director-mcp")
         data['mcpServers'] = {
             "cluster-director-mcp": {
                 "command": mcp_binary_path,


### PR DESCRIPTION
This PR updates the run.sh script in the release branch to support execution on any GCP VMs by adding a go mod tidy step to install Go dependencies, complete with a fail-safe that stops execution and provides a targeted troubleshooting message (checking for Go installation, disk space, or network issues) if the command fails. 
Additionally, 
It cleans up the Gemini CLI configuration by removing the context7 MCP server from being automatically added to the user's $HOME/.gemini/settings.json file. 