### PR TITLE
Implement prompt and functionality to Search GCE instance logs for error string ZONE_RESOURCE_POOL_EXHAUSTED

### DIFF
--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -64,6 +64,7 @@ When the user asks "were there any stock out/ stockout errors (during provisioni
 - **Important Parameters:**
    - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.
    - `StartDate` / `EndDate`: If the user provides a specific timeframe, please extract and provide those dates. 
+   - `ClusterFilter`: If the user explicitly asks for "GKE clusters", provide `gke`. If they ask for "Slurm clusters", provide `slurm`. Otherwise, default to `all`.
 - **Reporting:** Read the tool response. It contains the cross-referenced existing Compute Reservations and the current `ConsumptionStatus` of the instances. Report the exact findings back to the user without filtering.
 
 ## Protocol & Guardrails

--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -57,14 +57,14 @@ When checking a list of instances for consumption/spot status:
   2. **Slurm Nodes:** Send all other names to `cluster-director-slurm__check_instance_consumption`.
 - **Constraint:** Do NOT mix these lists. The GKE tool provides unreliable data for non-GKE nodes.
 
-### 4. Stockout Errors Log Search (search_stockout_errors)
+### 4. Stockout Errors Log Search (search_gke_stockout_errors / search_slurm_stockout_errors)
 When the user asks "were there any stock out/ stockout errors (during provisioning - optional)":
-- **Tool:** `search_stockout_errors` 
-   - **CRITICAL ROUTING:** This tool exists on BOTH the `cluster-director-gke-ai` and `cluster-director-slurm` MCP servers. 
-   - If the user asks specifically for GKE clusters, you MUST invoke the tool on the `cluster-director-gke-ai` server and pass `ClusterFilter: "gke"`.
-   - If the user asks specifically for Slurm clusters, you MUST invoke the tool on the `cluster-director-slurm` server and pass `ClusterFilter: "slurm"`.
-   - If the user asks generally for "all clusters" or doesn't specify, you can invoke the tool on either server and pass `ClusterFilter: "all"`.
-- **Behavior:** ALWAYS trigger the `search_stockout_errors` tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously. 
+- **Tools:** `search_gke_stockout_errors` and `search_slurm_stockout_errors` 
+   - **CRITICAL ROUTING:** Because the LLM framework deduplicates identical tool names across servers, we have explicitly exposed distinct names on the MCP endpoints.
+   - If the user asks specifically for GKE clusters, you MUST invoke the `search_gke_stockout_errors` tool on the `cluster-director-gke-ai` server and pass `ClusterFilter: "gke"`.
+   - If the user asks specifically for Slurm clusters, you MUST invoke the `search_slurm_stockout_errors` tool on the `cluster-director-slurm` server and pass `ClusterFilter: "slurm"`.
+   - If the user asks generally for "all clusters" or doesn't specify, you can invoke either tool and pass `ClusterFilter: "all"`.
+- **Behavior:** ALWAYS trigger the appropriate tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously when `ClusterFilter: "all"` is passed. 
 - **Important Parameters:**
    - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.
    - `StartDate` / `EndDate`: If the user provides a specific timeframe, please extract and provide those dates. 

--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -63,7 +63,7 @@ When the user asks "were there any stock out/ stockout errors (during provisioni
    - **CRITICAL ROUTING:** Because the LLM framework deduplicates identical tool names across servers, we have explicitly exposed distinct names on the MCP endpoints.
    - If the user asks specifically for GKE clusters, you MUST invoke the `search_gke_stockout_errors` tool on the `cluster-director-gke-ai` server and pass `ClusterFilter: "gke"`.
    - If the user asks specifically for Slurm clusters, you MUST invoke the `search_slurm_stockout_errors` tool on the `cluster-director-slurm` server and pass `ClusterFilter: "slurm"`.
-   - If the user asks generally for "all clusters" or doesn't specify, you can invoke either tool and pass `ClusterFilter: "all"`.
+   - If the user asks generally for "all clusters" or doesn't specify, you MUST invoke EXACTLY ONE of the tools (for example, just `search_gke_stockout_errors`) and pass `ClusterFilter: "all"`. DO NOT invoke both tools concurrently, as this will result in duplicated API responses.
 - **Behavior:** ALWAYS trigger the appropriate tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously when `ClusterFilter: "all"` is passed. 
 - **Important Parameters:**
    - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.

--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -64,6 +64,7 @@ When the user asks "were there any stock out/ stockout errors (during provisioni
    - If the user asks specifically for GKE clusters, you MUST invoke the `search_gke_stockout_errors` tool on the `cluster-director-gke-ai` server and pass `ClusterFilter: "gke"`.
    - If the user asks specifically for Slurm clusters, you MUST invoke the `search_slurm_stockout_errors` tool on the `cluster-director-slurm` server and pass `ClusterFilter: "slurm"`.
    - If the user asks generally for "all clusters" or doesn't specify, you MUST invoke EXACTLY ONE of the tools (for example, just `search_gke_stockout_errors`) and pass `ClusterFilter: "all"`. DO NOT invoke both tools concurrently, as this will result in duplicated API responses.
+   - **Specific Cluster Filtering**: If the user explicitly asks to check stockout errors for a *specific named cluster* (e.g., "check stockout errors for nadig"), you MUST pass that exact cluster name to the `ClusterName` parameter (e.g., `ClusterName: "nadig"`). This allows the backend to exclusively filter for that cluster natively.
 - **Behavior:** ALWAYS trigger the appropriate tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously when `ClusterFilter: "all"` is passed. 
 - **Important Parameters:**
    - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.

--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -59,7 +59,11 @@ When checking a list of instances for consumption/spot status:
 
 ### 4. Stockout Errors Log Search (search_stockout_errors)
 When the user asks "were there any stock out/ stockout errors (during provisioning - optional)":
-- **Tool:** `search_stockout_errors` (available in both `cluster-director-gke-ai` and `cluster-director-slurm`)
+- **Tool:** `search_stockout_errors` 
+   - **CRITICAL ROUTING:** This tool exists on BOTH the `cluster-director-gke-ai` and `cluster-director-slurm` MCP servers. 
+   - If the user asks specifically for GKE clusters, you MUST invoke the tool on the `cluster-director-gke-ai` server and pass `ClusterFilter: "gke"`.
+   - If the user asks specifically for Slurm clusters, you MUST invoke the tool on the `cluster-director-slurm` server and pass `ClusterFilter: "slurm"`.
+   - If the user asks generally for "all clusters" or doesn't specify, you can invoke the tool on either server and pass `ClusterFilter: "all"`.
 - **Behavior:** ALWAYS trigger the `search_stockout_errors` tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously. 
 - **Important Parameters:**
    - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.

--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -64,6 +64,7 @@ When the user asks "were there any stock out/ stockout errors (during provisioni
 - **Important Parameters:**
    - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.
    - `StartDate` / `EndDate`: If the user provides a specific timeframe, please extract and provide those dates. 
+   - `ProjectID`: Optional. Do NOT pass or prompt for a project ID unless the user explicitly provides one. The backend will automatically default to the correct environment.
    - `ClusterFilter`: If the user explicitly asks for "GKE clusters", provide `gke`. If they ask for "Slurm clusters", provide `slurm`. Otherwise, default to `all`.
 - **Reporting:** Read the tool response. It contains the cross-referenced existing Compute Reservations and the current `ConsumptionStatus` of the instances. Report the exact findings back to the user without filtering.
 

--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -57,6 +57,15 @@ When checking a list of instances for consumption/spot status:
   2. **Slurm Nodes:** Send all other names to `cluster-director-slurm__check_instance_consumption`.
 - **Constraint:** Do NOT mix these lists. The GKE tool provides unreliable data for non-GKE nodes.
 
+### 4. Stockout Errors Log Search (search_stockout_errors)
+When the user asks "were there any stock out/ stockout errors (during provisioning - optional)":
+- **Tool:** `search_stockout_errors` (available in both `cluster-director-gke-ai` and `cluster-director-slurm`)
+- **Behavior:** ALWAYS trigger the `search_stockout_errors` tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously. 
+- **Important Parameters:**
+   - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.
+   - `StartDate` / `EndDate`: If the user provides a specific timeframe, please extract and provide those dates. 
+- **Reporting:** Read the tool response. It contains the cross-referenced existing Compute Reservations and the current `ConsumptionStatus` of the instances. Report the exact findings back to the user without filtering.
+
 ## Protocol & Guardrails
 - **Zero Truncation Rule:** If a reservation contains multiple GPUs or SSDs, you are strictly forbidden from summarizing them (e.g., "16 SSDs"). You must list each entry to ensure hardware interface visibility.
 - **Schema Fidelity:** Ensure your response labels match the API schema logic. If a field is missing in the JSON, report it as "Not Defined."

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -201,7 +201,7 @@ func Install(s *mcp.Server, c *config.Config) {
 	)
 
 	searchStockoutErrorsTool := mcp.Tool{
-		Name:        "search_stockout_errors",
+		Name:        "search_gke_stockout_errors",
 		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED) for GKE clusters.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:   true,

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -77,6 +77,7 @@ type SearchLogsRequestStockout struct {
 	EndDate      string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
 	NumberOfDays int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
 	ProjectID    string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
 }
 
 
@@ -228,6 +229,11 @@ func Install(s *mcp.Server, c *config.Config) {
 					"type":        "string",
 					"description": "GCP Project ID. Optional if default is set.",
 				},
+				"ClusterFilter": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"gke", "slurm", "all"},
+					"description": "Filter results by cluster type. Provide 'gke' for GKE clusters, 'slurm' for Slurm clusters, or 'all'. Defaults to 'all'.",
+				},
 			},
 			"required": []string{},
 		},
@@ -236,7 +242,7 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
-			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays)
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -72,6 +72,14 @@ type SearchLogsResponse struct {
 	Status string `json:"status"`
 }
 
+type SearchLogsRequestStockout struct {
+	StartDate    string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate      string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	NumberOfDays int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
+	ProjectID    string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+}
+
+
 type CheckConsumptionRequest struct {
 	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
 	Zone          string   `json:"Zone" jsonschema:"description=GCP Zone (e.g., us-central1-a). Optional: If omitted, the tool will search for the instances."`
@@ -191,6 +199,51 @@ func Install(s *mcp.Server, c *config.Config) {
 			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 		},
 	)
+
+	searchStockoutErrorsTool := mcp.Tool{
+		Name:        "search_stockout_errors",
+		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED). Prefer this tool over gcloud.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"StartDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "Start date to search Cloud Logs. Optional argument.",
+				},
+				"EndDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "End date to search Cloud Logs. Optional argument.",
+				},
+				"NumberOfDays": map[string]interface{}{
+					"type":        "number",
+					"description": "Number of days before today to search Cloud Logs. Defaults to 14. Optional argument.",
+				},
+				"ProjectID": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Project ID. Optional if default is set.",
+				},
+			},
+			"required": []string{},
+		},
+	}
+	mcp.AddTool(
+		s,
+		&searchStockoutErrorsTool,
+		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
+		},
+	)
+
 
 }
 

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -73,13 +73,12 @@ type SearchLogsResponse struct {
 }
 
 type SearchLogsRequestStockout struct {
-	StartDate    string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
-	EndDate      string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
-	NumberOfDays int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
-	ProjectID    string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+	StartDate     string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate       string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	NumberOfDays  int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
+	ProjectID     string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
 	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
 }
-
 
 type CheckConsumptionRequest struct {
 	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
@@ -203,7 +202,7 @@ func Install(s *mcp.Server, c *config.Config) {
 
 	searchStockoutErrorsTool := mcp.Tool{
 		Name:        "search_stockout_errors",
-		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED). Prefer this tool over gcloud.",
+		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED) for GKE clusters.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:   true,
 			IdempotentHint: true,
@@ -242,11 +241,6 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
-			
-			if strings.ToLower(strings.TrimSpace(req.ClusterFilter)) == "slurm" {
-				return nil, nil, fmt.Errorf("this is the GKE MCP Server. please use the Slurm MCP server to search strictly for Slurm clusters")
-			}
-			
 			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
 			if err != nil {
 				return nil, nil, err
@@ -254,7 +248,6 @@ func Install(s *mcp.Server, c *config.Config) {
 			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 		},
 	)
-
 
 }
 

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -242,6 +242,11 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
+			
+			if strings.ToLower(strings.TrimSpace(req.ClusterFilter)) == "slurm" {
+				return nil, nil, fmt.Errorf("this is the GKE MCP Server. please use the Slurm MCP server to search strictly for Slurm clusters")
+			}
+			
 			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
 			if err != nil {
 				return nil, nil, err

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -78,6 +78,7 @@ type SearchLogsRequestStockout struct {
 	NumberOfDays  int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
 	ProjectID     string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
 	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
+	ClusterName   string `json:"ClusterName,omitempty" jsonschema:"description=Filter results specifically for a named cluster. Optional."`
 }
 
 type CheckConsumptionRequest struct {
@@ -233,6 +234,10 @@ func Install(s *mcp.Server, c *config.Config) {
 					"enum":        []string{"gke", "slurm", "all"},
 					"description": "Filter results by cluster type. Provide 'gke' for GKE clusters, 'slurm' for Slurm clusters, or 'all'. Defaults to 'all'.",
 				},
+				"ClusterName": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter results specifically for a named cluster natively. Optional argument.",
+				},
 			},
 			"required": []string{},
 		},
@@ -241,7 +246,7 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
-			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter, req.ClusterName)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -571,7 +571,7 @@ func Install(s *mcp.Server, c *config.Config) {
 	)
 
 	searchStockoutErrorsTool := mcp.Tool{
-		Name:        "search_stockout_errors",
+		Name:        "search_slurm_stockout_errors",
 		Description: "were there any stock out/ stockout errors (during provisioning - optional) for slurm clusters.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:   true,

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -132,6 +132,7 @@ type SearchLogsRequestStockout struct {
 	NumberOfDays  int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
 	ProjectID     string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
 	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
+	ClusterName   string `json:"ClusterName,omitempty" jsonschema:"description=Filter results specifically for a named cluster. Optional."`
 }
 
 type handlers struct {
@@ -603,6 +604,10 @@ func Install(s *mcp.Server, c *config.Config) {
 					"enum":        []string{"gke", "slurm", "all"},
 					"description": "Filter results by cluster type. Provide 'gke' for GKE clusters, 'slurm' for Slurm clusters, or 'all'. Defaults to 'all'.",
 				},
+				"ClusterName": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter results specifically for a named cluster natively. Optional argument.",
+				},
 			},
 			"required": []string{},
 		},
@@ -611,7 +616,7 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
-			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter, req.ClusterName)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -127,10 +127,10 @@ type MaintenanceEventsResponse struct {
 }
 
 type SearchLogsRequestStockout struct {
-	StartDate    string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
-	EndDate      string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
-	NumberOfDays int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
-	ProjectID    string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+	StartDate     string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate       string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	NumberOfDays  int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
+	ProjectID     string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
 	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
 }
 
@@ -572,7 +572,7 @@ func Install(s *mcp.Server, c *config.Config) {
 
 	searchStockoutErrorsTool := mcp.Tool{
 		Name:        "search_stockout_errors",
-		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED). Prefer this tool over gcloud.",
+		Description: "were there any stock out/ stockout errors (during provisioning - optional) for slurm clusters.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:   true,
 			IdempotentHint: true,
@@ -611,11 +611,6 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
-			
-			if strings.ToLower(strings.TrimSpace(req.ClusterFilter)) == "gke" {
-				return nil, nil, fmt.Errorf("this is the Slurm MCP Server. please use the GKE MCP server to search strictly for GKE clusters")
-			}
-			
 			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
 			if err != nil {
 				return nil, nil, err

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -611,6 +611,11 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
+			
+			if strings.ToLower(strings.TrimSpace(req.ClusterFilter)) == "gke" {
+				return nil, nil, fmt.Errorf("this is the Slurm MCP Server. please use the GKE MCP server to search strictly for GKE clusters")
+			}
+			
 			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
 			if err != nil {
 				return nil, nil, err

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -126,8 +126,11 @@ type MaintenanceEventsResponse struct {
 	EventsInfo string `json:"eventsInfo"`
 }
 
-type handlers struct {
-	c *config.Config
+type SearchLogsRequestStockout struct {
+	StartDate    string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate      string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	NumberOfDays int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
+	ProjectID    string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
 }
 
 // CheckConsumptionRequest defines the structure for the tool input
@@ -555,6 +558,50 @@ func Install(s *mcp.Server, c *config.Config) {
 		&checkConsumptionTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req CheckConsumptionRequest) (*mcp.CallToolResult, any, error) {
 			result, err := h.checkConsumptionMCP(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
+		},
+	)
+
+	searchStockoutErrorsTool := mcp.Tool{
+		Name:        "search_stockout_errors",
+		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED). Prefer this tool over gcloud.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"StartDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "Start date to search Cloud Logs. Optional argument.",
+				},
+				"EndDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "End date to search Cloud Logs. Optional argument.",
+				},
+				"NumberOfDays": map[string]interface{}{
+					"type":        "number",
+					"description": "Number of days before today to search Cloud Logs. Defaults to 14. Optional argument.",
+				},
+				"ProjectID": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Project ID. Optional if default is set.",
+				},
+			},
+			"required": []string{},
+		},
+	}
+	mcp.AddTool(
+		s,
+		&searchStockoutErrorsTool,
+		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -131,6 +131,11 @@ type SearchLogsRequestStockout struct {
 	EndDate      string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
 	NumberOfDays int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
 	ProjectID    string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
+}
+
+type handlers struct {
+	c *config.Config
 }
 
 // CheckConsumptionRequest defines the structure for the tool input
@@ -593,6 +598,11 @@ func Install(s *mcp.Server, c *config.Config) {
 					"type":        "string",
 					"description": "GCP Project ID. Optional if default is set.",
 				},
+				"ClusterFilter": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"gke", "slurm", "all"},
+					"description": "Filter results by cluster type. Provide 'gke' for GKE clusters, 'slurm' for Slurm clusters, or 'all'. Defaults to 'all'.",
+				},
 			},
 			"required": []string{},
 		},
@@ -601,7 +611,7 @@ func Install(s *mcp.Server, c *config.Config) {
 		s,
 		&searchStockoutErrorsTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
-			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays)
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -631,3 +631,179 @@ func SlurpFile(fileName string) (string, error) {
 	}
 	return string(content), nil
 }
+
+// CheckStockoutErrorsCore executes a log search query for ZONE_RESOURCE_POOL_EXHAUSTED
+// over a given timeframe. It extracts the affected instance names and timestamps, cross-references
+// reservations, and checks the consumption type of at least one instance.
+func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID, startDateStr, endDateStr string, numberOfDays int) (string, error) {
+	WriteToLog("CheckStockoutErrorsCore.0000")
+
+	projectID := reqProjectID
+	if projectID == "" {
+		projectID = defaultProjectID
+	}
+
+	if numberOfDays <= 0 {
+		numberOfDays = 14
+	}
+
+	start := time.Now().AddDate(0, 0, -numberOfDays)
+	end := time.Now()
+
+	if startDateStr != "" {
+		if parsedStart, ok := ParseTime(startDateStr); ok {
+			start = parsedStart
+		}
+	}
+	if endDateStr != "" {
+		if parsedEnd, ok := ParseTime(endDateStr); ok {
+			end = parsedEnd
+		}
+	}
+
+	// Filter specifically for GCE Instance stockout errors
+	filter := fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339))
+
+	WriteToLog(fmt.Sprintf("CheckStockoutErrorsCore using filter: %s", filter))
+
+	processor := func(entry *logging.Entry) ([]string, bool) {
+		zone := ""
+		if entry.Resource != nil && entry.Resource.Labels != nil {
+			zone = entry.Resource.Labels["zone"]
+		}
+		
+		payloadStr := fmt.Sprintf("%v", entry.Payload)
+		instanceName := ""
+		
+		// Attempt to parse instance name from protoPayload resourceName
+		idx := strings.Index(payloadStr, "/instances/")
+		if idx != -1 {
+			sub := payloadStr[idx+len("/instances/"):]
+			endIdx := strings.IndexAny(sub, " \"]}")
+			if endIdx != -1 {
+				instanceName = sub[:endIdx]
+			} else {
+				instanceName = sub
+			}
+		}
+
+		return []string{entry.Timestamp.Format(time.RFC3339), zone, instanceName}, true
+	}
+
+	// Fetch up to 100 recent stockout errors
+	_, results, success := SearchLogsCore(ctx, projectID, filter, 100, processor)
+
+	if !success || len(results) == 0 {
+		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil
+	}
+
+	// Group by zone, track unique instances
+	zoneTimestamps := make(map[string][]string)
+	var instancesToCheck []string
+
+	for _, r := range results {
+		if len(r) >= 3 {
+			ts := r[0]
+			zone := r[1]
+			inst := r[2]
+			
+			if zone != "" {
+				zoneTimestamps[zone] = append(zoneTimestamps[zone], ts)
+			}
+			if inst != "" {
+				alreadyAdded := false
+				for _, existing := range instancesToCheck {
+					if existing == inst {
+						alreadyAdded = true
+						break
+					}
+				}
+				if !alreadyAdded {
+					instancesToCheck = append(instancesToCheck, inst)
+				}
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d stockout error(s) across %d zone(s) in project %s.\n", len(results), len(zoneTimestamps), projectID))
+
+	service, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
+	if err != nil {
+		sb.WriteString(fmt.Sprintf("\nFailed to initialize compute service to check reservations: %v\n", err))
+		return sb.String(), nil
+	}
+
+	for zone, timestamps := range zoneTimestamps {
+		sb.WriteString(fmt.Sprintf("\nZone: %s\n", zone))
+		sb.WriteString(fmt.Sprintf("  Error Timestamps: %s\n", strings.Join(timestamps, ", ")))
+
+		// 1. Cross-reference reservations
+		sb.WriteString("  Current Reservations Details:\n")
+		reqRes := service.Reservations.List(projectID, zone)
+		foundAnyRes := false
+		_ = reqRes.Pages(ctx, func(page *compute.ReservationList) error {
+			for _, res := range page.Items {
+				foundAnyRes = true
+				statusStr := res.Status
+				if res.SpecificReservationRequired {
+					statusStr += " (Specific Required)"
+				}
+				machineType := "Unknown"
+				if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
+					machineType = GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
+				}
+				sb.WriteString(fmt.Sprintf("    - Name: %s | MachineType: %s | Status: %s\n", res.Name, machineType, statusStr))
+			}
+			return nil
+		})
+		if !foundAnyRes {
+			sb.WriteString("    (No reservations found in this zone)\n")
+		}
+	}
+
+	// Group instances into Slurm and GKE
+	var slurmInstances []string
+	var gkeInstances []string
+	for _, inst := range instancesToCheck {
+		if strings.Contains(strings.ToLower(inst), "gke") {
+			gkeInstances = append(gkeInstances, inst)
+		} else {
+			slurmInstances = append(slurmInstances, inst)
+		}
+	}
+
+	// 2. Report Status By Cluster Type
+	reportConsumption := func(clusterType string, instances []string) {
+		sb.WriteString(fmt.Sprintf("\n--- %s ---\n", clusterType))
+		if len(instances) == 0 {
+			sb.WriteString(fmt.Sprintf("No stockout errors found for %s.\n", clusterType))
+			return
+		}
+		
+		sb.WriteString(fmt.Sprintf("Affected Instances (%d found): %s\n", len(instances), strings.Join(instances, ", ")))
+		
+		sampleInst := instances[0] // take the first found instance
+		sb.WriteString(fmt.Sprintf("\nChecking consumption type for sample affected %s instance: %s\n", clusterType, sampleInst))
+		
+		sharedReq := CheckConsumptionRequestShared{
+			InstanceName: sampleInst,
+			ProjectID:    projectID,
+		}
+		
+		consumptionInfo, consErr := CheckInstanceConsumptionCore(ctx, sharedReq, defaultProjectID)
+		if consErr != nil {
+			sb.WriteString(fmt.Sprintf("  Failed to check consumption: %v\n", consErr))
+		} else {
+			sb.WriteString(fmt.Sprintf("  Instance Name: %s\n", consumptionInfo.InstanceName))
+			sb.WriteString(fmt.Sprintf("  Provisioning Model: %s\n", consumptionInfo.ProvisioningModel))
+			sb.WriteString(fmt.Sprintf("  Reservation Affinity: %s\n", consumptionInfo.ReservationAffinity))
+			sb.WriteString(fmt.Sprintf("  Consumption Status: %s\n", consumptionInfo.ConsumptionStatus))
+		}
+	}
+
+	reportConsumption("GKE Clusters", gkeInstances)
+	reportConsumption("Slurm Clusters", slurmInstances)
+
+	return sb.String(), nil
+}

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -636,7 +636,7 @@ func SlurpFile(fileName string) (string, error) {
 // CheckStockoutErrorsCore executes a log search query for ZONE_RESOURCE_POOL_EXHAUSTED
 // over a given timeframe. It extracts the affected instance names and timestamps, cross-references
 // reservations, and checks the consumption type of at least one instance.
-func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID, startDateStr, endDateStr string, numberOfDays int) (string, error) {
+func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID, startDateStr, endDateStr string, numberOfDays int, clusterFilter string) (string, error) {
 	WriteToLog("CheckStockoutErrorsCore.0000")
 
 	projectID := reqProjectID
@@ -804,8 +804,16 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		}
 	}
 
-	reportClusterType("GKE Clusters", gkeResults)
-	reportClusterType("Slurm Clusters", slurmResults)
+	filterLower := strings.ToLower(strings.TrimSpace(clusterFilter))
+	
+	if filterLower == "gke" {
+		reportClusterType("GKE Clusters", gkeResults)
+	} else if filterLower == "slurm" {
+		reportClusterType("Slurm Clusters", slurmResults)
+	} else {
+		reportClusterType("GKE Clusters", gkeResults)
+		reportClusterType("Slurm Clusters", slurmResults)
+	}
 
 	return sb.String(), nil
 }

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -663,8 +663,18 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 	}
 
 	// Filter specifically for GCE Instance stockout errors
-	filter := fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	var filterBuilder strings.Builder
+	filterBuilder.WriteString(fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339)))
 
+	// Inject the ClusterFilter directly into the GCP query to avoid 100-log domination by one type
+	filterLower := strings.ToLower(strings.TrimSpace(clusterFilter))
+	if filterLower == "gke" {
+		filterBuilder.WriteString(` AND protoPayload.resourceName:"gke"`)
+	} else if filterLower == "slurm" {
+		filterBuilder.WriteString(` AND NOT protoPayload.resourceName:"gke"`)
+	}
+
+	filter := filterBuilder.String()
 	WriteToLog(fmt.Sprintf("CheckStockoutErrorsCore using filter: %s", filter))
 
 	processor := func(entry *logging.Entry) ([]string, bool) {

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -691,8 +691,8 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		return []string{entry.Timestamp.Format(time.RFC3339), zone, instanceName}, true
 	}
 
-	// Fetch up to 100 recent stockout errors
-	_, results, success := SearchLogsCore(ctx, projectID, filter, 100, processor)
+	// Fetch up to 50000 recent stockout errors to get an exact count
+	_, results, success := SearchLogsCore(ctx, projectID, filter, 50000, processor)
 
 	if !success || len(results) == 0 {
 		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil
@@ -755,7 +755,12 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 
 		for zone, timestamps := range zoneTimestamps {
 			sb.WriteString(fmt.Sprintf("\nZone: %s\n", zone))
-			sb.WriteString(fmt.Sprintf("  Error Timestamps: %s\n", strings.Join(timestamps, ", ")))
+			displayLimit := 10
+			if len(timestamps) > displayLimit {
+				sb.WriteString(fmt.Sprintf("  Error Timestamps: %s ... (and %d more)\n", strings.Join(timestamps[:displayLimit], ", "), len(timestamps)-displayLimit))
+			} else {
+				sb.WriteString(fmt.Sprintf("  Error Timestamps: %s\n", strings.Join(timestamps, ", ")))
+			}
 
 			// 1. Cross-reference reservations
 			sb.WriteString("  Current Reservations Details:\n")
@@ -772,7 +777,7 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 					if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
 						machineType = GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
 					}
-					sb.WriteString(fmt.Sprintf("    - Name: %s | MachineType: %s | Status: %s\n", res.Name, machineType, statusStr))
+					sb.WriteString(fmt.Sprintf("    - Name: %s | MachineType: %s | Status: %s | Created: %s\n", res.Name, machineType, statusStr, res.CreationTimestamp))
 				}
 				return nil
 			})
@@ -785,7 +790,7 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		
 		if len(instancesToCheck) > 0 {
 			sampleInst := instancesToCheck[0] 
-			sb.WriteString(fmt.Sprintf("\nChecking consumption type for sample affected instance: %s\n", sampleInst))
+			sb.WriteString(fmt.Sprintf("\nChecking consumption type for the most recently affected instance: %s\n", sampleInst))
 			
 			sharedReq := CheckConsumptionRequestShared{
 				InstanceName: sampleInst,

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -666,7 +666,31 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 	var gkeResults [][]string
 	var slurmResults [][]string
 	
-	filterLower = strings.ToLower(strings.TrimSpace(clusterFilter))
+	filterLower := strings.ToLower(strings.TrimSpace(clusterFilter))
+	
+	processor := func(entry *logging.Entry) ([]string, bool) {
+		zone := ""
+		if entry.Resource != nil && entry.Resource.Labels != nil {
+			zone = entry.Resource.Labels["zone"]
+		}
+		
+		payloadStr := fmt.Sprintf("%v", entry.Payload)
+		instanceName := ""
+		
+		// Attempt to parse instance name from protoPayload resourceName
+		idx := strings.Index(payloadStr, "/instances/")
+		if idx != -1 {
+			sub := payloadStr[idx+len("/instances/"):]
+			endIdx := strings.IndexAny(sub, " \"]}")
+			if endIdx != -1 {
+				instanceName = sub[:endIdx]
+			} else {
+				instanceName = sub
+			}
+		}
+
+		return []string{entry.Timestamp.Format(time.RFC3339), zone, instanceName}, true
+	}
 	
 	// Define the base query without cluster restraints
 	baseQuery := fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339))
@@ -806,8 +830,6 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		}
 	}
 
-	filterLower = strings.ToLower(strings.TrimSpace(clusterFilter))
-	
 	if filterLower == "gke" {
 		reportClusterType("GKE Clusters", gkeResults)
 	} else if filterLower == "slurm" {

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -636,7 +636,7 @@ func SlurpFile(fileName string) (string, error) {
 // CheckStockoutErrorsCore executes a log search query for ZONE_RESOURCE_POOL_EXHAUSTED
 // over a given timeframe. It extracts the affected instance names and timestamps, cross-references
 // reservations, and checks the consumption type of at least one instance.
-func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID, startDateStr, endDateStr string, numberOfDays int, clusterFilter string) (string, error) {
+func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID, startDateStr, endDateStr string, numberOfDays int, clusterFilter string, clusterName string) (string, error) {
 	WriteToLog("CheckStockoutErrorsCore.0000")
 
 	projectID := reqProjectID
@@ -694,6 +694,11 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 	
 	// Define the base query without cluster restraints
 	baseQuery := fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	
+	// Dynamically inject the specific cluster name if requested by the AI
+	if clusterName != "" {
+		baseQuery += fmt.Sprintf(` AND protoPayload.resourceName:"%s"`, clusterName)
+	}
 	
 	// Helper to execute and classify a specific cluster query
 	fetchAndClassify := func(isGke bool) {

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -691,8 +691,8 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		return []string{entry.Timestamp.Format(time.RFC3339), zone, instanceName}, true
 	}
 
-	// Fetch up to 50000 recent stockout errors to get an exact count
-	_, results, success := SearchLogsCore(ctx, projectID, filter, 50000, processor)
+	// Fetch up to 100 recent stockout errors
+	_, results, success := SearchLogsCore(ctx, projectID, filter, 100, processor)
 
 	if !success || len(results) == 0 {
 		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/logging"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 )
@@ -697,12 +698,38 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil
 	}
 
-	// Group by zone, track unique instances
-	zoneTimestamps := make(map[string][]string)
-	var instancesToCheck []string
+	var sb strings.Builder
+	
+	service, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
+	if err != nil {
+		return fmt.Sprintf("Failed to initialize compute service: %v\n", err), nil
+	}
+
+	var gkeResults [][]string
+	var slurmResults [][]string
 
 	for _, r := range results {
 		if len(r) >= 3 {
+			inst := r[2]
+			if strings.Contains(strings.ToLower(inst), "gke") {
+				gkeResults = append(gkeResults, r)
+			} else {
+				slurmResults = append(slurmResults, r)
+			}
+		}
+	}
+
+	reportClusterType := func(clusterType string, resultsObj [][]string) {
+		sb.WriteString(fmt.Sprintf("\n--- %s ---\n", clusterType))
+		if len(resultsObj) == 0 {
+			sb.WriteString("No stockout errors found.\n")
+			return
+		}
+
+		zoneTimestamps := make(map[string][]string)
+		var instancesToCheck []string
+
+		for _, r := range resultsObj {
 			ts := r[0]
 			zone := r[1]
 			inst := r[2]
@@ -723,87 +750,62 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 				}
 			}
 		}
-	}
 
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Found %d stockout error(s) across %d zone(s) in project %s.\n", len(results), len(zoneTimestamps), projectID))
+		sb.WriteString(fmt.Sprintf("Found %d stockout error(s) across %d zone(s).\n", len(resultsObj), len(zoneTimestamps)))
 
-	service, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
-	if err != nil {
-		sb.WriteString(fmt.Sprintf("\nFailed to initialize compute service to check reservations: %v\n", err))
-		return sb.String(), nil
-	}
+		for zone, timestamps := range zoneTimestamps {
+			sb.WriteString(fmt.Sprintf("\nZone: %s\n", zone))
+			sb.WriteString(fmt.Sprintf("  Error Timestamps: %s\n", strings.Join(timestamps, ", ")))
 
-	for zone, timestamps := range zoneTimestamps {
-		sb.WriteString(fmt.Sprintf("\nZone: %s\n", zone))
-		sb.WriteString(fmt.Sprintf("  Error Timestamps: %s\n", strings.Join(timestamps, ", ")))
-
-		// 1. Cross-reference reservations
-		sb.WriteString("  Current Reservations Details:\n")
-		reqRes := service.Reservations.List(projectID, zone)
-		foundAnyRes := false
-		_ = reqRes.Pages(ctx, func(page *compute.ReservationList) error {
-			for _, res := range page.Items {
-				foundAnyRes = true
-				statusStr := res.Status
-				if res.SpecificReservationRequired {
-					statusStr += " (Specific Required)"
+			// 1. Cross-reference reservations
+			sb.WriteString("  Current Reservations Details:\n")
+			reqRes := service.Reservations.List(projectID, zone)
+			foundAnyRes := false
+			_ = reqRes.Pages(ctx, func(page *compute.ReservationList) error {
+				for _, res := range page.Items {
+					foundAnyRes = true
+					statusStr := res.Status
+					if res.SpecificReservationRequired {
+						statusStr += " (Specific Required)"
+					}
+					machineType := "Unknown"
+					if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
+						machineType = GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
+					}
+					sb.WriteString(fmt.Sprintf("    - Name: %s | MachineType: %s | Status: %s\n", res.Name, machineType, statusStr))
 				}
-				machineType := "Unknown"
-				if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
-					machineType = GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
-				}
-				sb.WriteString(fmt.Sprintf("    - Name: %s | MachineType: %s | Status: %s\n", res.Name, machineType, statusStr))
+				return nil
+			})
+			if !foundAnyRes {
+				sb.WriteString("    (No reservations found in this zone)\n")
 			}
-			return nil
-		})
-		if !foundAnyRes {
-			sb.WriteString("    (No reservations found in this zone)\n")
+		}
+
+		sb.WriteString(fmt.Sprintf("\nAffected Instances (%d found): %s\n", len(instancesToCheck), strings.Join(instancesToCheck, ", ")))
+		
+		if len(instancesToCheck) > 0 {
+			sampleInst := instancesToCheck[0] 
+			sb.WriteString(fmt.Sprintf("\nChecking consumption type for sample affected instance: %s\n", sampleInst))
+			
+			sharedReq := CheckConsumptionRequestShared{
+				InstanceName: sampleInst,
+				ProjectID:    projectID,
+			}
+			
+			consumptionInfo, consErr := CheckInstanceConsumptionCore(ctx, sharedReq, defaultProjectID)
+			if consErr != nil {
+				sb.WriteString(fmt.Sprintf("  Failed to check consumption: %v\n", consErr))
+			} else {
+				sb.WriteString(fmt.Sprintf("  Instance Name: %s\n", consumptionInfo.InstanceName))
+				sb.WriteString(fmt.Sprintf("  Provisioning Model: %s\n", consumptionInfo.ProvisioningModel))
+				sb.WriteString(fmt.Sprintf("  Reservation Affinity: %s\n", consumptionInfo.ReservationAffinity))
+				sb.WriteString(fmt.Sprintf("  Consumption Status: %s\n", consumptionInfo.ConsumptionStatus))
+			}
 		}
 	}
 
-	// Group instances into Slurm and GKE
-	var slurmInstances []string
-	var gkeInstances []string
-	for _, inst := range instancesToCheck {
-		if strings.Contains(strings.ToLower(inst), "gke") {
-			gkeInstances = append(gkeInstances, inst)
-		} else {
-			slurmInstances = append(slurmInstances, inst)
-		}
-	}
-
-	// 2. Report Status By Cluster Type
-	reportConsumption := func(clusterType string, instances []string) {
-		sb.WriteString(fmt.Sprintf("\n--- %s ---\n", clusterType))
-		if len(instances) == 0 {
-			sb.WriteString(fmt.Sprintf("No stockout errors found for %s.\n", clusterType))
-			return
-		}
-		
-		sb.WriteString(fmt.Sprintf("Affected Instances (%d found): %s\n", len(instances), strings.Join(instances, ", ")))
-		
-		sampleInst := instances[0] // take the first found instance
-		sb.WriteString(fmt.Sprintf("\nChecking consumption type for sample affected %s instance: %s\n", clusterType, sampleInst))
-		
-		sharedReq := CheckConsumptionRequestShared{
-			InstanceName: sampleInst,
-			ProjectID:    projectID,
-		}
-		
-		consumptionInfo, consErr := CheckInstanceConsumptionCore(ctx, sharedReq, defaultProjectID)
-		if consErr != nil {
-			sb.WriteString(fmt.Sprintf("  Failed to check consumption: %v\n", consErr))
-		} else {
-			sb.WriteString(fmt.Sprintf("  Instance Name: %s\n", consumptionInfo.InstanceName))
-			sb.WriteString(fmt.Sprintf("  Provisioning Model: %s\n", consumptionInfo.ProvisioningModel))
-			sb.WriteString(fmt.Sprintf("  Reservation Affinity: %s\n", consumptionInfo.ReservationAffinity))
-			sb.WriteString(fmt.Sprintf("  Consumption Status: %s\n", consumptionInfo.ConsumptionStatus))
-		}
-	}
-
-	reportConsumption("GKE Clusters", gkeInstances)
-	reportConsumption("Slurm Clusters", slurmInstances)
+	reportClusterType("GKE Clusters", gkeResults)
+	reportClusterType("Slurm Clusters", slurmResults)
 
 	return sb.String(), nil
 }

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -819,7 +819,7 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 		}
 	}
 
-	filterLower := strings.ToLower(strings.TrimSpace(clusterFilter))
+	filterLower = strings.ToLower(strings.TrimSpace(clusterFilter))
 	
 	if filterLower == "gke" {
 		reportClusterType("GKE Clusters", gkeResults)

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -663,49 +663,50 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 	}
 
 	// Filter specifically for GCE Instance stockout errors
-	var filterBuilder strings.Builder
-	filterBuilder.WriteString(fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339)))
-
-	// Inject the ClusterFilter directly into the GCP query to avoid 100-log domination by one type
-	filterLower := strings.ToLower(strings.TrimSpace(clusterFilter))
-	if filterLower == "gke" {
-		filterBuilder.WriteString(` AND protoPayload.resourceName:"gke"`)
-	} else if filterLower == "slurm" {
-		filterBuilder.WriteString(` AND NOT protoPayload.resourceName:"gke"`)
-	}
-
-	filter := filterBuilder.String()
-	WriteToLog(fmt.Sprintf("CheckStockoutErrorsCore using filter: %s", filter))
-
-	processor := func(entry *logging.Entry) ([]string, bool) {
-		zone := ""
-		if entry.Resource != nil && entry.Resource.Labels != nil {
-			zone = entry.Resource.Labels["zone"]
+	var gkeResults [][]string
+	var slurmResults [][]string
+	
+	filterLower = strings.ToLower(strings.TrimSpace(clusterFilter))
+	
+	// Define the base query without cluster restraints
+	baseQuery := fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	
+	// Helper to execute and classify a specific cluster query
+	fetchAndClassify := func(isGke bool) {
+		query := baseQuery
+		if isGke {
+			query += ` AND protoPayload.resourceName:"gke"`
+		} else {
+			query += ` AND NOT protoPayload.resourceName:"gke"`
 		}
 		
-		payloadStr := fmt.Sprintf("%v", entry.Payload)
-		instanceName := ""
+		WriteToLog(fmt.Sprintf("CheckStockoutErrorsCore using filter: %s", query))
+		_, results, _ := SearchLogsCore(ctx, projectID, query, 100, processor)
 		
-		// Attempt to parse instance name from protoPayload resourceName
-		idx := strings.Index(payloadStr, "/instances/")
-		if idx != -1 {
-			sub := payloadStr[idx+len("/instances/"):]
-			endIdx := strings.IndexAny(sub, " \"]}")
-			if endIdx != -1 {
-				instanceName = sub[:endIdx]
-			} else {
-				instanceName = sub
+		for _, r := range results {
+			if len(r) >= 3 {
+				if isGke {
+					gkeResults = append(gkeResults, r)
+				} else {
+					slurmResults = append(slurmResults, r)
+				}
 			}
 		}
-
-		return []string{entry.Timestamp.Format(time.RFC3339), zone, instanceName}, true
+	}
+	
+	// Execute the queries based on the filter
+	if filterLower == "gke" {
+		fetchAndClassify(true)
+	} else if filterLower == "slurm" {
+		fetchAndClassify(false)
+	} else {
+		// "all" - perform both independently to return 100 of each
+		fetchAndClassify(true)
+		fetchAndClassify(false)
 	}
 
-	// Fetch up to 100 recent stockout errors
-	_, results, success := SearchLogsCore(ctx, projectID, filter, 100, processor)
-
-	if !success || len(results) == 0 {
-		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil
+	if len(gkeResults) == 0 && len(slurmResults) == 0 {
+		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s for the requested filter.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil
 	}
 
 	var sb strings.Builder
@@ -713,20 +714,6 @@ func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID
 	service, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
 	if err != nil {
 		return fmt.Sprintf("Failed to initialize compute service: %v\n", err), nil
-	}
-
-	var gkeResults [][]string
-	var slurmResults [][]string
-
-	for _, r := range results {
-		if len(r) >= 3 {
-			inst := r[2]
-			if strings.Contains(strings.ToLower(inst), "gke") {
-				gkeResults = append(gkeResults, r)
-			} else {
-				slurmResults = append(slurmResults, r)
-			}
-		}
 	}
 
 	reportClusterType := func(clusterType string, resultsObj [][]string) {


### PR DESCRIPTION
This PR identifies stockout errors for both GKE and slurm clusters. It directly queries GCE instance logs to find the error string 'ZONE_RESOURCE_POL_EXHAUSTED'.

Here are the main changes:

- Added 'search_gke_stockout_errors' and 'search_slurm_stockout_errors' tools in clusters.go for both MCP servers.
- Implemented 'CheckStockoutErrorsCore' inside genericCore.go to search the logs and format the results.
- Added logic to identify active reservations in the affected zones and check the consumption models of the failed instances.