### PR TITLE
Implement prompt and functionality to Search GCE instance logs for error string ZONE_RESOURCE_POOL_EXHAUSTED

### DIFF
--- a/.gemini/skills/compute-reservation-expert/SKILL.md
+++ b/.gemini/skills/compute-reservation-expert/SKILL.md
@@ -57,6 +57,22 @@ When checking a list of instances for consumption/spot status:
   2. **Slurm Nodes:** Send all other names to `cluster-director-slurm__check_instance_consumption`.
 - **Constraint:** Do NOT mix these lists. The GKE tool provides unreliable data for non-GKE nodes.
 
+### 4. Stockout Errors Log Search (search_gke_stockout_errors / search_slurm_stockout_errors)
+When the user asks "were there any stock out/ stockout errors (during provisioning - optional)":
+- **Tools:** `search_gke_stockout_errors` and `search_slurm_stockout_errors` 
+   - **CRITICAL ROUTING:** Because the LLM framework deduplicates identical tool names across servers, we have explicitly exposed distinct names on the MCP endpoints.
+   - If the user asks specifically for GKE clusters, you MUST invoke the `search_gke_stockout_errors` tool on the `cluster-director-gke-ai` server and pass `ClusterFilter: "gke"`.
+   - If the user asks specifically for Slurm clusters, you MUST invoke the `search_slurm_stockout_errors` tool on the `cluster-director-slurm` server and pass `ClusterFilter: "slurm"`.
+   - If the user asks generally for "all clusters" or doesn't specify, you MUST invoke EXACTLY ONE of the tools (for example, just `search_gke_stockout_errors`) and pass `ClusterFilter: "all"`. DO NOT invoke both tools concurrently, as this will result in duplicated API responses.
+   - **Specific Cluster Filtering**: If the user explicitly asks to check stockout errors for a *specific named cluster* (e.g., "check stockout errors for nadig"), you MUST pass that exact cluster name to the `ClusterName` parameter (e.g., `ClusterName: "nadig"`). This allows the backend to exclusively filter for that cluster natively.
+- **Behavior:** ALWAYS trigger the appropriate tool to search the GCP Logs globally for `ZONE_RESOURCE_POOL_EXHAUSTED`. This single tool call works globally for the project, checking both GKE and Slurm cluster nodes simultaneously when `ClusterFilter: "all"` is passed. 
+- **Important Parameters:**
+   - `NumberOfDays`: Must default to `14`, unless the user specifies otherwise.
+   - `StartDate` / `EndDate`: If the user provides a specific timeframe, please extract and provide those dates. 
+   - `ProjectID`: Optional. Do NOT pass or prompt for a project ID unless the user explicitly provides one. The backend will automatically default to the correct environment.
+   - `ClusterFilter`: If the user explicitly asks for "GKE clusters", provide `gke`. If they ask for "Slurm clusters", provide `slurm`. Otherwise, default to `all`.
+- **Reporting:** Read the tool response. It contains the cross-referenced existing Compute Reservations and the current `ConsumptionStatus` of the instances. Report the exact findings back to the user without filtering.
+
 ## Protocol & Guardrails
 - **Zero Truncation Rule:** If a reservation contains multiple GPUs or SSDs, you are strictly forbidden from summarizing them (e.g., "16 SSDs"). You must list each entry to ensure hardware interface visibility.
 - **Schema Fidelity:** Ensure your response labels match the API schema logic. If a field is missing in the JSON, report it as "Not Defined."

--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -72,6 +72,15 @@ type SearchLogsResponse struct {
 	Status string `json:"status"`
 }
 
+type SearchLogsRequestStockout struct {
+	StartDate     string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate       string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	NumberOfDays  int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
+	ProjectID     string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
+	ClusterName   string `json:"ClusterName,omitempty" jsonschema:"description=Filter results specifically for a named cluster. Optional."`
+}
+
 type CheckConsumptionRequest struct {
 	InstanceNames []string `json:"InstanceNames" jsonschema:"description=List of GCE instance names to check"`
 	Zone          string   `json:"Zone" jsonschema:"description=GCP Zone (e.g., us-central1-a). Optional: If omitted, the tool will search for the instances."`
@@ -185,6 +194,59 @@ func Install(s *mcp.Server, c *config.Config) {
 		&checkConsumptionTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req CheckConsumptionRequest) (*mcp.CallToolResult, any, error) {
 			result, err := h.checkConsumptionMCP(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
+		},
+	)
+
+	searchStockoutErrorsTool := mcp.Tool{
+		Name:        "search_gke_stockout_errors",
+		Description: "were there any stock out/ stockout errors (during provisioning - optional) (ZONE_RESOURCE_POOL_EXHAUSTED) for GKE clusters.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"StartDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "Start date to search Cloud Logs. Optional argument.",
+				},
+				"EndDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "End date to search Cloud Logs. Optional argument.",
+				},
+				"NumberOfDays": map[string]interface{}{
+					"type":        "number",
+					"description": "Number of days before today to search Cloud Logs. Defaults to 14. Optional argument.",
+				},
+				"ProjectID": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Project ID. Optional if default is set.",
+				},
+				"ClusterFilter": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"gke", "slurm", "all"},
+					"description": "Filter results by cluster type. Provide 'gke' for GKE clusters, 'slurm' for Slurm clusters, or 'all'. Defaults to 'all'.",
+				},
+				"ClusterName": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter results specifically for a named cluster natively. Optional argument.",
+				},
+			},
+			"required": []string{},
+		},
+	}
+	mcp.AddTool(
+		s,
+		&searchStockoutErrorsTool,
+		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter, req.ClusterName)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -126,6 +126,15 @@ type MaintenanceEventsResponse struct {
 	EventsInfo string `json:"eventsInfo"`
 }
 
+type SearchLogsRequestStockout struct {
+	StartDate     string `json:"StartDate,omitempty" jsonschema:"description=Start date to search Cloud Logs"`
+	EndDate       string `json:"EndDate,omitempty" jsonschema:"description=End date to search Cloud Logs"`
+	NumberOfDays  int    `json:"NumberOfDays,omitempty" jsonschema:"default=14,description=Number of days before today to search Cloud Logs"`
+	ProjectID     string `json:"ProjectID,omitempty" jsonschema:"description=GCP Project ID. Optional if default is set."`
+	ClusterFilter string `json:"ClusterFilter,omitempty" jsonschema:"description=Filter results by cluster type. Valid values: 'gke', 'slurm', or 'all' (default)."`
+	ClusterName   string `json:"ClusterName,omitempty" jsonschema:"description=Filter results specifically for a named cluster. Optional."`
+}
+
 type handlers struct {
 	c *config.Config
 }
@@ -555,6 +564,59 @@ func Install(s *mcp.Server, c *config.Config) {
 		&checkConsumptionTool,
 		func(ctx context.Context, _ *mcp.CallToolRequest, req CheckConsumptionRequest) (*mcp.CallToolResult, any, error) {
 			result, err := h.checkConsumptionMCP(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
+		},
+	)
+
+	searchStockoutErrorsTool := mcp.Tool{
+		Name:        "search_slurm_stockout_errors",
+		Description: "were there any stock out/ stockout errors (during provisioning - optional) for slurm clusters.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"StartDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "Start date to search Cloud Logs. Optional argument.",
+				},
+				"EndDate": map[string]interface{}{
+					"type":        "string",
+					"format":      "date",
+					"description": "End date to search Cloud Logs. Optional argument.",
+				},
+				"NumberOfDays": map[string]interface{}{
+					"type":        "number",
+					"description": "Number of days before today to search Cloud Logs. Defaults to 14. Optional argument.",
+				},
+				"ProjectID": map[string]interface{}{
+					"type":        "string",
+					"description": "GCP Project ID. Optional if default is set.",
+				},
+				"ClusterFilter": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"gke", "slurm", "all"},
+					"description": "Filter results by cluster type. Provide 'gke' for GKE clusters, 'slurm' for Slurm clusters, or 'all'. Defaults to 'all'.",
+				},
+				"ClusterName": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter results specifically for a named cluster natively. Optional argument.",
+				},
+			},
+			"required": []string{},
+		},
+	}
+	mcp.AddTool(
+		s,
+		&searchStockoutErrorsTool,
+		func(ctx context.Context, _ *mcp.CallToolRequest, req SearchLogsRequestStockout) (*mcp.CallToolResult, any, error) {
+			result, err := genericCore.CheckStockoutErrorsCore(ctx, h.c.GetDefaultProjectID(), req.ProjectID, req.StartDate, req.EndDate, req.NumberOfDays, req.ClusterFilter, req.ClusterName)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1316,6 +1378,7 @@ func verifyAndUpdateStatusOfRunningJobsOnClusterAndReturnListOfRunningJobs(proje
 	}
 
 	return returnMessage, returnSuccess
+
 }
 
 func checkCDMcpJobStatusCore(projectID string) (string, error) {

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/logging"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 )
@@ -630,4 +631,218 @@ func SlurpFile(fileName string) (string, error) {
 		return "", err
 	}
 	return string(content), nil
+}
+
+// CheckStockoutErrorsCore executes a log search query for ZONE_RESOURCE_POOL_EXHAUSTED
+// over a given timeframe. It extracts the affected instance names and timestamps, cross-references
+// reservations, and checks the consumption type of at least one instance.
+func CheckStockoutErrorsCore(ctx context.Context, defaultProjectID, reqProjectID, startDateStr, endDateStr string, numberOfDays int, clusterFilter string, clusterName string) (string, error) {
+	WriteToLog("CheckStockoutErrorsCore.0000")
+
+	projectID := reqProjectID
+	if projectID == "" {
+		projectID = defaultProjectID
+	}
+
+	if numberOfDays <= 0 {
+		numberOfDays = 14
+	}
+
+	start := time.Now().AddDate(0, 0, -numberOfDays)
+	end := time.Now()
+
+	if startDateStr != "" {
+		if parsedStart, ok := ParseTime(startDateStr); ok {
+			start = parsedStart
+		}
+	}
+	if endDateStr != "" {
+		if parsedEnd, ok := ParseTime(endDateStr); ok {
+			end = parsedEnd
+		}
+	}
+
+	// Filter specifically for GCE Instance stockout errors
+	var gkeResults [][]string
+	var slurmResults [][]string
+
+	filterLower := strings.ToLower(strings.TrimSpace(clusterFilter))
+
+	processor := func(entry *logging.Entry) ([]string, bool) {
+		zone := ""
+		if entry.Resource != nil && entry.Resource.Labels != nil {
+			zone = entry.Resource.Labels["zone"]
+		}
+
+		payloadStr := fmt.Sprintf("%v", entry.Payload)
+		instanceName := ""
+
+		// Attempt to parse instance name from protoPayload resourceName
+		idx := strings.Index(payloadStr, "/instances/")
+		if idx != -1 {
+			sub := payloadStr[idx+len("/instances/"):]
+			endIdx := strings.IndexAny(sub, " \"]}")
+			if endIdx != -1 {
+				instanceName = sub[:endIdx]
+			} else {
+				instanceName = sub
+			}
+		}
+
+		return []string{entry.Timestamp.Format(time.RFC3339), zone, instanceName}, true
+	}
+
+	// Define the base query without cluster restraints
+	baseQuery := fmt.Sprintf(`resource.type="gce_instance" AND protoPayload.status.message:"ZONE_RESOURCE_POOL_EXHAUSTED" AND timestamp >= "%s" AND timestamp <= "%s"`, start.Format(time.RFC3339), end.Format(time.RFC3339))
+
+	// Dynamically inject the specific cluster name if requested by the AI
+	if clusterName != "" {
+		baseQuery += fmt.Sprintf(` AND protoPayload.resourceName:"%s"`, clusterName)
+	}
+
+	// Helper to execute and classify a specific cluster query
+	fetchAndClassify := func(isGke bool) {
+		query := baseQuery
+		if isGke {
+			query += ` AND protoPayload.resourceName:"gke"`
+		} else {
+			query += ` AND NOT protoPayload.resourceName:"gke"`
+		}
+
+		WriteToLog(fmt.Sprintf("CheckStockoutErrorsCore using filter: %s", query))
+		_, results, _ := SearchLogsCore(ctx, projectID, query, 100, processor)
+
+		for _, r := range results {
+			if len(r) >= 3 {
+				if isGke {
+					gkeResults = append(gkeResults, r)
+				} else {
+					slurmResults = append(slurmResults, r)
+				}
+			}
+		}
+	}
+
+	// Execute the queries based on the filter
+	if filterLower == "gke" {
+		fetchAndClassify(true)
+	} else if filterLower == "slurm" {
+		fetchAndClassify(false)
+	} else {
+		// "all" - perform both independently to return 100 of each
+		fetchAndClassify(true)
+		fetchAndClassify(false)
+	}
+
+	if len(gkeResults) == 0 && len(slurmResults) == 0 {
+		return fmt.Sprintf("No stockout errors (ZONE_RESOURCE_POOL_EXHAUSTED) found in project %s between %s and %s for the requested filter.", projectID, start.Format("2006-01-02"), end.Format("2006-01-02")), nil
+	}
+
+	var sb strings.Builder
+
+	service, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
+	if err != nil {
+		return fmt.Sprintf("Failed to initialize compute service: %v\n", err), nil
+	}
+
+	reportClusterType := func(clusterType string, resultsObj [][]string) {
+		sb.WriteString(fmt.Sprintf("\n--- %s ---\n", clusterType))
+		if len(resultsObj) == 0 {
+			sb.WriteString("No stockout errors found.\n")
+			return
+		}
+
+		zoneTimestamps := make(map[string][]string)
+		var instancesToCheck []string
+
+		for _, r := range resultsObj {
+			ts := r[0]
+			zone := r[1]
+			inst := r[2]
+
+			if zone != "" {
+				zoneTimestamps[zone] = append(zoneTimestamps[zone], ts)
+			}
+			if inst != "" {
+				alreadyAdded := false
+				for _, existing := range instancesToCheck {
+					if existing == inst {
+						alreadyAdded = true
+						break
+					}
+				}
+				if !alreadyAdded {
+					instancesToCheck = append(instancesToCheck, inst)
+				}
+			}
+		}
+
+		sb.WriteString(fmt.Sprintf("Found %d stockout error(s) across %d zone(s).\n", len(resultsObj), len(zoneTimestamps)))
+
+		for zone, timestamps := range zoneTimestamps {
+			sb.WriteString(fmt.Sprintf("\nZone: %s\n", zone))
+			displayLimit := 10
+			if len(timestamps) > displayLimit {
+				sb.WriteString(fmt.Sprintf("  Error Timestamps: %s ... (and %d more)\n", strings.Join(timestamps[:displayLimit], ", "), len(timestamps)-displayLimit))
+			} else {
+				sb.WriteString(fmt.Sprintf("  Error Timestamps: %s\n", strings.Join(timestamps, ", ")))
+			}
+
+			// 1. Cross-reference reservations
+			sb.WriteString("  Current Reservations Details:\n")
+			reqRes := service.Reservations.List(projectID, zone)
+			foundAnyRes := false
+			_ = reqRes.Pages(ctx, func(page *compute.ReservationList) error {
+				for _, res := range page.Items {
+					foundAnyRes = true
+					statusStr := res.Status
+					if res.SpecificReservationRequired {
+						statusStr += " (Specific Required)"
+					}
+					machineType := "Unknown"
+					if res.SpecificReservation != nil && res.SpecificReservation.InstanceProperties != nil {
+						machineType = GetResourceNameFromURL(res.SpecificReservation.InstanceProperties.MachineType)
+					}
+					sb.WriteString(fmt.Sprintf("    - Name: %s | MachineType: %s | Status: %s | Created: %s\n", res.Name, machineType, statusStr, res.CreationTimestamp))
+				}
+				return nil
+			})
+			if !foundAnyRes {
+				sb.WriteString("    (No reservations found in this zone)\n")
+			}
+		}
+
+		sb.WriteString(fmt.Sprintf("\nAffected Instances (%d found): %s\n", len(instancesToCheck), strings.Join(instancesToCheck, ", ")))
+
+		if len(instancesToCheck) > 0 {
+			sampleInst := instancesToCheck[0]
+			sb.WriteString(fmt.Sprintf("\nChecking consumption type for the most recently affected instance: %s\n", sampleInst))
+
+			sharedReq := CheckConsumptionRequestShared{
+				InstanceName: sampleInst,
+				ProjectID:    projectID,
+			}
+
+			consumptionInfo, consErr := CheckInstanceConsumptionCore(ctx, sharedReq, defaultProjectID)
+			if consErr != nil {
+				sb.WriteString(fmt.Sprintf("  Failed to check consumption: %v\n", consErr))
+			} else {
+				sb.WriteString(fmt.Sprintf("  Instance Name: %s\n", consumptionInfo.InstanceName))
+				sb.WriteString(fmt.Sprintf("  Provisioning Model: %s\n", consumptionInfo.ProvisioningModel))
+				sb.WriteString(fmt.Sprintf("  Reservation Affinity: %s\n", consumptionInfo.ReservationAffinity))
+				sb.WriteString(fmt.Sprintf("  Consumption Status: %s\n", consumptionInfo.ConsumptionStatus))
+			}
+		}
+	}
+
+	if filterLower == "gke" {
+		reportClusterType("GKE Clusters", gkeResults)
+	} else if filterLower == "slurm" {
+		reportClusterType("Slurm Clusters", slurmResults)
+	} else {
+		reportClusterType("GKE Clusters", gkeResults)
+		reportClusterType("Slurm Clusters", slurmResults)
+	}
+
+	return sb.String(), nil
 }


### PR DESCRIPTION
This PR identifies stockout errors for both GKE and slurm clusters. It directly queries GCE instance logs to find the error string 'ZONE_RESOURCE_POL_EXHAUSTED'.

Here are the main changes:

- Added 'search_gke_stockout_errors' and 'search_slurm_stockout_errors' tools in clusters.go for both MCP servers.
- Implemented 'CheckStockoutErrorsCore' inside genericCore.go to search the logs and format the results.
- Added logic to identify active reservations in the affected zones and check the consumption models of the failed instances.