### PR TITLE
Updated run.sh to support Go dependencies on any GCP VMs 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,16 @@ echo "Updating cluster-director-mcp..."
 (git fetch --all 2>&1 > /dev/null ; git pull 2>&1 > /dev/null ; make -j  2>&1 > /dev/null) &
 git_pull_make_pid=$!
 
+# Sync Go dependencies
+echo "----"
+echo "Syncing Go dependencies..."
+go mod tidy
+if [ $? -ne 0 ]; then
+  echo "Error: 'go mod tidy' failed. Please ensure Go is installed."
+  echo "If Go is already installed, check for lack of disk space (run 'df -h') or network issues."
+  exit 1
+fi
+
 # Clean scratch
 echo "----"
 echo "Cleaning Scratch space..."


### PR DESCRIPTION
This PR updates the run.sh script to ensure the installer runs correctly on any standard GCP VMs outside of the typical Cloud Shell environment. 
Specifically, it adds a go mod tidy step to automatically sync Go dependencies before execution. 
To prevent downstream errors, it also implements a fail-safe that immediately halts the script if the dependency sync fails, providing users with a targeted troubleshooting message to quickly check for missing Go installations, lack of disk space via df -h, or network connectivity issues.