### PR TITLE
Truncate filepath to be relative after printing it once

### DIFF
--- a/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
+++ b/cluster-director-gke-ai/pkg/tools/cluster/cluster.go
@@ -414,6 +414,7 @@ func parseXidNumber(logLine string) string {
 }
 
 func (h *handlers) checkConsumptionMCP(ctx context.Context, req CheckConsumptionRequest) (string, error) {
+	genericCore.WriteToLog(fmt.Sprintf("Received MCP tool request: check_instance_consumption for %d instances", len(req.InstanceNames)))
 	return genericCore.ProcessConsumptionRequest(
 		ctx,
 		req.InstanceNames,

--- a/cluster-director-slurm/pkg/tools/cluster/cluster.go
+++ b/cluster-director-slurm/pkg/tools/cluster/cluster.go
@@ -1519,6 +1519,7 @@ func getVersionCheckStatus(projectID string, jobObj *persistence.LongRunningJob)
 
 // Implementation
 func (h *handlers) checkConsumptionMCP(ctx context.Context, req CheckConsumptionRequest) (string, error) {
+	genericCore.WriteToLog(fmt.Sprintf("Received MCP tool request: check_instance_consumption for %d instances", len(req.InstanceNames)))
 	return genericCore.ProcessConsumptionRequest(
 		ctx,
 		req.InstanceNames,

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/logging"
@@ -37,6 +38,10 @@ import (
 const maxLogFiles = 100
 
 var logger *slog.Logger
+
+var seenFiles sync.Map
+
+var projectRoot string
 
 // GcloudListItem represents a single item from the gcloud list command's JSON output.
 type GcloudListItem struct {
@@ -59,6 +64,56 @@ type InstanceConsumptionStatus struct {
 	ConsumptionStatus   string `json:"consumption_status"`
 }
 
+func init() {
+	// Grab the current working directory when the program starts
+	projectRoot, _ = os.Getwd()
+}
+
+func formatFilePath(fullPath string) string {
+	// Try to get the already-calculated short path.
+	// We use an empty string "" as a placeholder to claim the "first" spot.
+	val, alreadySeen := seenFiles.LoadOrStore(fullPath, "")
+
+	if !alreadySeen {
+		// First time seeing this file! We need to calculate the short path.
+		shortPath := ""
+
+		if projectRoot != "" {
+			rel, err := filepath.Rel(projectRoot, fullPath)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				shortPath = rel
+			}
+		}
+
+		// Fallback: If Rel failed or produced an ugly path
+		if shortPath == "" {
+			if idx := strings.Index(fullPath, "cluster-director-mcp/"); idx != -1 {
+				shortPath = fullPath[idx+len("cluster-director-mcp/"):]
+			} else {
+				shortPath = filepath.Base(fullPath)
+			}
+		}
+
+		// Update the map to hold the actual calculated short path
+		seenFiles.Store(fullPath, shortPath)
+
+		// The requirement is to return the absolute path the *first* time
+		return fullPath
+	}
+
+	// If we have already seen it, grab the string from the map
+	shortPath := val.(string)
+
+	// Edge case: If two goroutines hit this at the exact same millisecond,
+	// one might read the "" placeholder before the other finishes calculating.
+	// If so, just safely print the full path.
+	if shortPath == "" {
+		return fullPath
+	}
+
+	// Return the cached short path!
+	return shortPath
+}
 func WriteToLog(message string) {
 
 	message = strings.ReplaceAll(message, "\n", " | ")
@@ -168,7 +223,8 @@ func (h *PlainHandler) Handle(ctx context.Context, r slog.Record) error {
 	if h.opts.AddSource && r.PC != 0 {
 		fs := runtime.CallersFrames([]uintptr{r.PC})
 		f, _ := fs.Next()
-		sourceStr = fmt.Sprintf("%s:%d", f.File, f.Line)
+		displayPath := formatFilePath(f.File)
+		sourceStr = fmt.Sprintf("%s:%d", displayPath, f.Line)
 	}
 
 	// 3. Format Level

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -72,12 +72,9 @@ func init() {
 }
 
 func formatFilePath(fullPath string) string {
-	// Try to get the already-calculated short path.
-	// We use an empty string "" as a placeholder to claim the "first" spot.
 	val, alreadySeen := seenFiles.LoadOrStore(fullPath, "")
 
 	if !alreadySeen {
-		// First time seeing this file! We need to calculate the short path.
 		shortPath := ""
 
 		if projectRoot != "" {
@@ -96,19 +93,13 @@ func formatFilePath(fullPath string) string {
 			}
 		}
 
-		// Update the map to hold the actual calculated short path
 		seenFiles.Store(fullPath, shortPath)
 
-		// The requirement is to return the absolute path the *first* time
 		return fullPath
 	}
 
-	// If we have already seen it, grab the string from the map
 	shortPath := val.(string)
 
-	// Edge case: If two goroutines hit this at the exact same millisecond,
-	// one might read the "" placeholder before the other finishes calculating.
-	// If so, just safely print the full path.
 	if shortPath == "" {
 		return fullPath
 	}
@@ -116,6 +107,7 @@ func formatFilePath(fullPath string) string {
 	// Return the cached short path!
 	return shortPath
 }
+
 func WriteToLog(message string) {
 
 	message = strings.ReplaceAll(message, "\n", " | ")

--- a/genericCore/genericCore.go
+++ b/genericCore/genericCore.go
@@ -517,6 +517,8 @@ func CheckInstanceConsumptionCore(ctx context.Context, req CheckConsumptionReque
 	req.Zone = strings.TrimSpace(req.Zone)
 	req.ProjectID = strings.TrimSpace(req.ProjectID)
 
+	WriteToLog(fmt.Sprintf("Evaluating consumption status for instance: '%s'", req.InstanceName))
+
 	var status InstanceConsumptionStatus
 	status.InstanceName = req.InstanceName
 	status.Zone = req.Zone


### PR DESCRIPTION
This PR updates the logging mechanism to truncate file paths to relative paths after printing the full absolute path once per file.
The logger now uses a thread-safe cache to store and retrieve the shortened path (e.g., cluster-director-gke-ai/...) on all subsequent log entries for that file. 
This eliminates unnecessary clutter and improves log readability while maintaining efficient, high-performance logging.